### PR TITLE
Fix missing manifest causing Gradle build failure

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,18 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.penmasnews">
+
+    <application
+        android:allowBackup="true"
+        android:label="@string/app_name"
+        android:theme="@style/Theme.MaterialComponents.DayNight.DarkActionBar">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Penmas News</string>
+</resources>


### PR DESCRIPTION
## Summary
- add an Android manifest for the app module
- define the app name string resource used by the manifest

## Testing
- `gradle assembleDebug` *(fails: No Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_6875f784ff448327be2b39db0d988cb5