### PR TITLE
Add editorial calendar design doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,7 @@ repository, build and run it using Android Studio with the SDK installed.
 ```
 
 Open the project in Android Studio to edit and run on a device or emulator.
+
+## Dokumentasi Desain
+
+- [Kalender Editorial & Ide](docs/editorial_calendar.md)

--- a/docs/editorial_calendar.md
+++ b/docs/editorial_calendar.md
@@ -1,0 +1,36 @@
+# Kalender Editorial & Ide
+
+Halaman kalender editorial berfungsi sebagai pusat perencanaan konten.
+
+## Konsep
+
+Modul ini menampilkan kalender harian, mingguan, atau bulanan yang memuat:
+
+- **Ide Topik**: catatan singkat atau link riset.
+- **Penjadwalan**: tanggal dan waktu publikasi.
+- **Penugasan**: reporter/editor yang bertanggung jawab.
+- **Status**: label proses seperti _draft_, _review_, hingga _publish_.
+
+## Fungsi Utama
+
+1. **Perencanaan & Monitoring** – melihat alur produksi dalam satu tampilan kalender.
+2. **Kolaborasi & Transparansi** – semua anggota tim dapat memantau tugas dan tenggat.
+3. **Manajemen Beban Kerja** – membantu distribusi penugasan agar merata.
+4. **Sinkronisasi Deadline** – pengingat otomatis mendekati tenggat waktu.
+5. **Integrasi** – menghubungkan hasil riset tren atau sistem manajemen proyek lain.
+
+## Maksud & Tujuan
+
+- Menjamin konsistensi jadwal publikasi.
+- Mengurangi miskomunikasi dalam koordinasi tim.
+- Mengoptimalkan kapasitas sumber daya.
+- Mempermudah penyesuaian agenda jika ada berita mendadak.
+
+## Alur Kerja Singkat
+
+1. **Ide & Penjadwalan** – editor menambahkan topik ke kalender dan menetapkan reporter.
+2. **Penulisan & Riset** – reporter mengerjakan draf dengan dukungan AI untuk riset cepat.
+3. **Review & Revisi** – editor menilai dan memberi masukan hingga siap terbit.
+4. **Persiapan Multimedia** – unggah aset dan lampirkan ke artikel.
+5. **Persetujuan & Publikasi** – konten diterbitkan ke CMS dan kanal sosial.
+6. **Analisis & Optimasi** – memantau performa serta rekomendasi topik lanjutan.


### PR DESCRIPTION
## Summary
- document design concept for the editorial calendar feature
- link design document from README

## Testing
- `./gradlew assembleDebug` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687603973bec8327acd4abc58f9b5cab