### PR TITLE
Add basic forms with date picker and shared preferences

### DIFF
--- a/app/src/main/java/com/example/penmasnews/ui/AIHelperActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/AIHelperActivity.kt
@@ -1,12 +1,50 @@
 package com.example.penmasnews.ui
 
+import android.app.DatePickerDialog
 import android.os.Bundle
+import android.widget.Button
+import android.widget.EditText
 import androidx.appcompat.app.AppCompatActivity
 import com.example.penmasnews.R
+import java.util.Calendar
 
 class AIHelperActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_ai_helper)
+
+        val dateEdit = findViewById<EditText>(R.id.editDate)
+        val notesEdit = findViewById<EditText>(R.id.editNotes)
+        val saveButton = findViewById<Button>(R.id.buttonSave)
+
+        val prefs = getSharedPreferences(javaClass.simpleName, MODE_PRIVATE)
+
+        dateEdit.setText(prefs.getString("date", ""))
+        notesEdit.setText(prefs.getString("notes", ""))
+
+        dateEdit.setOnClickListener {
+            showDatePicker(dateEdit)
+        }
+
+        saveButton.setOnClickListener {
+            prefs.edit()
+                .putString("date", dateEdit.text.toString())
+                .putString("notes", notesEdit.text.toString())
+                .apply()
+        }
+    }
+
+    private fun showDatePicker(target: EditText) {
+        val cal = Calendar.getInstance()
+        DatePickerDialog(
+            this,
+            { _, year, month, day ->
+                val result = String.format("%02d-%02d-%04d", day, month + 1, year)
+                target.setText(result)
+            },
+            cal.get(Calendar.YEAR),
+            cal.get(Calendar.MONTH),
+            cal.get(Calendar.DAY_OF_MONTH)
+        ).show()
     }
 }

--- a/app/src/main/java/com/example/penmasnews/ui/AnalyticsDashboardActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/AnalyticsDashboardActivity.kt
@@ -1,12 +1,50 @@
 package com.example.penmasnews.ui
 
+import android.app.DatePickerDialog
 import android.os.Bundle
+import android.widget.Button
+import android.widget.EditText
 import androidx.appcompat.app.AppCompatActivity
 import com.example.penmasnews.R
+import java.util.Calendar
 
 class AnalyticsDashboardActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_analytics_dashboard)
+
+        val dateEdit = findViewById<EditText>(R.id.editDate)
+        val notesEdit = findViewById<EditText>(R.id.editNotes)
+        val saveButton = findViewById<Button>(R.id.buttonSave)
+
+        val prefs = getSharedPreferences(javaClass.simpleName, MODE_PRIVATE)
+
+        dateEdit.setText(prefs.getString("date", ""))
+        notesEdit.setText(prefs.getString("notes", ""))
+
+        dateEdit.setOnClickListener {
+            showDatePicker(dateEdit)
+        }
+
+        saveButton.setOnClickListener {
+            prefs.edit()
+                .putString("date", dateEdit.text.toString())
+                .putString("notes", notesEdit.text.toString())
+                .apply()
+        }
+    }
+
+    private fun showDatePicker(target: EditText) {
+        val cal = Calendar.getInstance()
+        DatePickerDialog(
+            this,
+            { _, year, month, day ->
+                val result = String.format("%02d-%02d-%04d", day, month + 1, year)
+                target.setText(result)
+            },
+            cal.get(Calendar.YEAR),
+            cal.get(Calendar.MONTH),
+            cal.get(Calendar.DAY_OF_MONTH)
+        ).show()
     }
 }

--- a/app/src/main/java/com/example/penmasnews/ui/AssetManagerActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/AssetManagerActivity.kt
@@ -1,12 +1,50 @@
 package com.example.penmasnews.ui
 
+import android.app.DatePickerDialog
 import android.os.Bundle
+import android.widget.Button
+import android.widget.EditText
 import androidx.appcompat.app.AppCompatActivity
 import com.example.penmasnews.R
+import java.util.Calendar
 
 class AssetManagerActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_asset_manager)
+
+        val dateEdit = findViewById<EditText>(R.id.editDate)
+        val notesEdit = findViewById<EditText>(R.id.editNotes)
+        val saveButton = findViewById<Button>(R.id.buttonSave)
+
+        val prefs = getSharedPreferences(javaClass.simpleName, MODE_PRIVATE)
+
+        dateEdit.setText(prefs.getString("date", ""))
+        notesEdit.setText(prefs.getString("notes", ""))
+
+        dateEdit.setOnClickListener {
+            showDatePicker(dateEdit)
+        }
+
+        saveButton.setOnClickListener {
+            prefs.edit()
+                .putString("date", dateEdit.text.toString())
+                .putString("notes", notesEdit.text.toString())
+                .apply()
+        }
+    }
+
+    private fun showDatePicker(target: EditText) {
+        val cal = Calendar.getInstance()
+        DatePickerDialog(
+            this,
+            { _, year, month, day ->
+                val result = String.format("%02d-%02d-%04d", day, month + 1, year)
+                target.setText(result)
+            },
+            cal.get(Calendar.YEAR),
+            cal.get(Calendar.MONTH),
+            cal.get(Calendar.DAY_OF_MONTH)
+        ).show()
     }
 }

--- a/app/src/main/java/com/example/penmasnews/ui/CMSIntegrationActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/CMSIntegrationActivity.kt
@@ -1,12 +1,50 @@
 package com.example.penmasnews.ui
 
+import android.app.DatePickerDialog
 import android.os.Bundle
+import android.widget.Button
+import android.widget.EditText
 import androidx.appcompat.app.AppCompatActivity
 import com.example.penmasnews.R
+import java.util.Calendar
 
 class CMSIntegrationActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_cms_integration)
+
+        val dateEdit = findViewById<EditText>(R.id.editDate)
+        val notesEdit = findViewById<EditText>(R.id.editNotes)
+        val saveButton = findViewById<Button>(R.id.buttonSave)
+
+        val prefs = getSharedPreferences(javaClass.simpleName, MODE_PRIVATE)
+
+        dateEdit.setText(prefs.getString("date", ""))
+        notesEdit.setText(prefs.getString("notes", ""))
+
+        dateEdit.setOnClickListener {
+            showDatePicker(dateEdit)
+        }
+
+        saveButton.setOnClickListener {
+            prefs.edit()
+                .putString("date", dateEdit.text.toString())
+                .putString("notes", notesEdit.text.toString())
+                .apply()
+        }
+    }
+
+    private fun showDatePicker(target: EditText) {
+        val cal = Calendar.getInstance()
+        DatePickerDialog(
+            this,
+            { _, year, month, day ->
+                val result = String.format("%02d-%02d-%04d", day, month + 1, year)
+                target.setText(result)
+            },
+            cal.get(Calendar.YEAR),
+            cal.get(Calendar.MONTH),
+            cal.get(Calendar.DAY_OF_MONTH)
+        ).show()
     }
 }

--- a/app/src/main/java/com/example/penmasnews/ui/CollaborativeEditorActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/CollaborativeEditorActivity.kt
@@ -1,12 +1,50 @@
 package com.example.penmasnews.ui
 
+import android.app.DatePickerDialog
 import android.os.Bundle
+import android.widget.Button
+import android.widget.EditText
 import androidx.appcompat.app.AppCompatActivity
 import com.example.penmasnews.R
+import java.util.Calendar
 
 class CollaborativeEditorActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_collaborative_editor)
+
+        val dateEdit = findViewById<EditText>(R.id.editDate)
+        val notesEdit = findViewById<EditText>(R.id.editNotes)
+        val saveButton = findViewById<Button>(R.id.buttonSave)
+
+        val prefs = getSharedPreferences(javaClass.simpleName, MODE_PRIVATE)
+
+        dateEdit.setText(prefs.getString("date", ""))
+        notesEdit.setText(prefs.getString("notes", ""))
+
+        dateEdit.setOnClickListener {
+            showDatePicker(dateEdit)
+        }
+
+        saveButton.setOnClickListener {
+            prefs.edit()
+                .putString("date", dateEdit.text.toString())
+                .putString("notes", notesEdit.text.toString())
+                .apply()
+        }
+    }
+
+    private fun showDatePicker(target: EditText) {
+        val cal = Calendar.getInstance()
+        DatePickerDialog(
+            this,
+            { _, year, month, day ->
+                val result = String.format("%02d-%02d-%04d", day, month + 1, year)
+                target.setText(result)
+            },
+            cal.get(Calendar.YEAR),
+            cal.get(Calendar.MONTH),
+            cal.get(Calendar.DAY_OF_MONTH)
+        ).show()
     }
 }

--- a/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
@@ -1,11 +1,15 @@
 package com.example.penmasnews.ui
 
+import android.app.DatePickerDialog
 import android.os.Bundle
+import android.widget.Button
+import android.widget.EditText
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.penmasnews.R
 import com.example.penmasnews.model.EditorialEvent
+import java.util.Calendar
 
 class EditorialCalendarActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -15,6 +19,24 @@ class EditorialCalendarActivity : AppCompatActivity() {
         val recyclerView = findViewById<RecyclerView>(R.id.recyclerViewCalendar)
         recyclerView.layoutManager = LinearLayoutManager(this)
 
+        val dateEdit = findViewById<EditText>(R.id.editDate)
+        val notesEdit = findViewById<EditText>(R.id.editNotes)
+        val saveButton = findViewById<Button>(R.id.buttonSave)
+
+        val prefs = getSharedPreferences(javaClass.simpleName, MODE_PRIVATE)
+
+        dateEdit.setText(prefs.getString("date", ""))
+        notesEdit.setText(prefs.getString("notes", ""))
+
+        dateEdit.setOnClickListener { showDatePicker(dateEdit) }
+
+        saveButton.setOnClickListener {
+            prefs.edit()
+                .putString("date", dateEdit.text.toString())
+                .putString("notes", notesEdit.text.toString())
+                .apply()
+        }
+
         // Sample data to illustrate the calendar design
         val events = listOf(
             EditorialEvent("1 Jan", "Refleksi Awal Tahun", "Andi", "draft"),
@@ -23,5 +45,19 @@ class EditorialCalendarActivity : AppCompatActivity() {
         )
 
         recyclerView.adapter = EditorialCalendarAdapter(events)
+    }
+
+    private fun showDatePicker(target: EditText) {
+        val cal = Calendar.getInstance()
+        DatePickerDialog(
+            this,
+            { _, year, month, day ->
+                val result = String.format("%02d-%02d-%04d", day, month + 1, year)
+                target.setText(result)
+            },
+            cal.get(Calendar.YEAR),
+            cal.get(Calendar.MONTH),
+            cal.get(Calendar.DAY_OF_MONTH)
+        ).show()
     }
 }

--- a/app/src/main/java/com/example/penmasnews/ui/WorkflowManagerActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/WorkflowManagerActivity.kt
@@ -1,12 +1,50 @@
 package com.example.penmasnews.ui
 
+import android.app.DatePickerDialog
 import android.os.Bundle
+import android.widget.Button
+import android.widget.EditText
 import androidx.appcompat.app.AppCompatActivity
 import com.example.penmasnews.R
+import java.util.Calendar
 
 class WorkflowManagerActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_workflow_manager)
+
+        val dateEdit = findViewById<EditText>(R.id.editDate)
+        val notesEdit = findViewById<EditText>(R.id.editNotes)
+        val saveButton = findViewById<Button>(R.id.buttonSave)
+
+        val prefs = getSharedPreferences(javaClass.simpleName, MODE_PRIVATE)
+
+        dateEdit.setText(prefs.getString("date", ""))
+        notesEdit.setText(prefs.getString("notes", ""))
+
+        dateEdit.setOnClickListener {
+            showDatePicker(dateEdit)
+        }
+
+        saveButton.setOnClickListener {
+            prefs.edit()
+                .putString("date", dateEdit.text.toString())
+                .putString("notes", notesEdit.text.toString())
+                .apply()
+        }
+    }
+
+    private fun showDatePicker(target: EditText) {
+        val cal = Calendar.getInstance()
+        DatePickerDialog(
+            this,
+            { _, year, month, day ->
+                val result = String.format("%02d-%02d-%04d", day, month + 1, year)
+                target.setText(result)
+            },
+            cal.get(Calendar.YEAR),
+            cal.get(Calendar.MONTH),
+            cal.get(Calendar.DAY_OF_MONTH)
+        ).show()
     }
 }

--- a/app/src/main/res/layout/activity_ai_helper.xml
+++ b/app/src/main/res/layout/activity_ai_helper.xml
@@ -20,5 +20,28 @@
             android:text="@string/desc_ai_helper"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
+
+        <EditText
+            android:id="@+id/editDate"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_date"
+            android:focusable="false"
+            android:clickable="true"
+            android:layout_marginTop="16dp" />
+
+        <EditText
+            android:id="@+id/editNotes"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_notes"
+            android:layout_marginTop="8dp" />
+
+        <Button
+            android:id="@+id/buttonSave"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/action_save"
+            android:layout_marginTop="8dp" />
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/activity_analytics_dashboard.xml
+++ b/app/src/main/res/layout/activity_analytics_dashboard.xml
@@ -20,5 +20,28 @@
             android:text="@string/desc_analytics_dashboard"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
+
+        <EditText
+            android:id="@+id/editDate"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_date"
+            android:focusable="false"
+            android:clickable="true"
+            android:layout_marginTop="16dp" />
+
+        <EditText
+            android:id="@+id/editNotes"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_notes"
+            android:layout_marginTop="8dp" />
+
+        <Button
+            android:id="@+id/buttonSave"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/action_save"
+            android:layout_marginTop="8dp" />
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/activity_asset_manager.xml
+++ b/app/src/main/res/layout/activity_asset_manager.xml
@@ -20,5 +20,28 @@
             android:text="@string/desc_asset_manager"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
+
+        <EditText
+            android:id="@+id/editDate"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_date"
+            android:focusable="false"
+            android:clickable="true"
+            android:layout_marginTop="16dp" />
+
+        <EditText
+            android:id="@+id/editNotes"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_notes"
+            android:layout_marginTop="8dp" />
+
+        <Button
+            android:id="@+id/buttonSave"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/action_save"
+            android:layout_marginTop="8dp" />
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/activity_cms_integration.xml
+++ b/app/src/main/res/layout/activity_cms_integration.xml
@@ -20,5 +20,28 @@
             android:text="@string/desc_cms_integration"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
+
+        <EditText
+            android:id="@+id/editDate"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_date"
+            android:focusable="false"
+            android:clickable="true"
+            android:layout_marginTop="16dp" />
+
+        <EditText
+            android:id="@+id/editNotes"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_notes"
+            android:layout_marginTop="8dp" />
+
+        <Button
+            android:id="@+id/buttonSave"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/action_save"
+            android:layout_marginTop="8dp" />
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/activity_collaborative_editor.xml
+++ b/app/src/main/res/layout/activity_collaborative_editor.xml
@@ -20,5 +20,28 @@
             android:text="@string/desc_collaborative_editor"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
+
+        <EditText
+            android:id="@+id/editDate"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_date"
+            android:focusable="false"
+            android:clickable="true"
+            android:layout_marginTop="16dp" />
+
+        <EditText
+            android:id="@+id/editNotes"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_notes"
+            android:layout_marginTop="8dp" />
+
+        <Button
+            android:id="@+id/buttonSave"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/action_save"
+            android:layout_marginTop="8dp" />
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/activity_editorial_calendar.xml
+++ b/app/src/main/res/layout/activity_editorial_calendar.xml
@@ -26,5 +26,28 @@
             android:id="@+id/recyclerViewCalendar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
+
+        <EditText
+            android:id="@+id/editDate"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_date"
+            android:focusable="false"
+            android:clickable="true"
+            android:layout_marginTop="16dp" />
+
+        <EditText
+            android:id="@+id/editNotes"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_notes"
+            android:layout_marginTop="8dp" />
+
+        <Button
+            android:id="@+id/buttonSave"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/action_save"
+            android:layout_marginTop="8dp" />
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/activity_workflow_manager.xml
+++ b/app/src/main/res/layout/activity_workflow_manager.xml
@@ -20,5 +20,28 @@
             android:text="@string/desc_workflow_manager"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
+
+        <EditText
+            android:id="@+id/editDate"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_date"
+            android:focusable="false"
+            android:clickable="true"
+            android:layout_marginTop="16dp" />
+
+        <EditText
+            android:id="@+id/editNotes"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_notes"
+            android:layout_marginTop="8dp" />
+
+        <Button
+            android:id="@+id/buttonSave"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/action_save"
+            android:layout_marginTop="8dp" />
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,4 +15,8 @@
     <string name="desc_workflow_manager">Memuat daftar draf dengan status draft, review, hingga final.\nSetiap entri dapat dibuka kembali di Penulisan Kolaboratif jika perlu revisi.\nSetelah disetujui, konten diteruskan ke Integrasi CMS.</string>
     <string name="desc_cms_integration">Menyediakan opsi publikasi ke situs web dan berbagai kanal sosial.\nSelesai publikasi, sistem mengarahkan pengguna untuk melihat Analitik.</string>
     <string name="desc_analytics_dashboard">Dashboard metrik performa artikel dan umpan balik pembaca.\nRekomendasi topik baru dapat langsung ditambahkan ke Kalender Editorial.</string>
+    <!-- common form hints -->
+    <string name="hint_date">Tanggal</string>
+    <string name="hint_notes">Catatan</string>
+    <string name="action_save">Simpan</string>
 </resources>


### PR DESCRIPTION
## Summary
- extend strings with form hints
- add date/notes inputs and save button for each feature activity
- implement SharedPreferences storage with date picker dialogs

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68760df8f2208327badbec951df4d793