### PR TITLE
Add topic field to editorial calendar

### DIFF
--- a/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
@@ -2,8 +2,11 @@ package com.example.penmasnews.ui
 
 import android.app.DatePickerDialog
 import android.os.Bundle
+import android.content.SharedPreferences
 import android.widget.Button
 import android.widget.EditText
+import org.json.JSONArray
+import org.json.JSONObject
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -20,31 +23,55 @@ class EditorialCalendarActivity : AppCompatActivity() {
         recyclerView.layoutManager = LinearLayoutManager(this)
 
         val dateEdit = findViewById<EditText>(R.id.editDate)
+        val topicEdit = findViewById<EditText>(R.id.editTopic)
         val notesEdit = findViewById<EditText>(R.id.editNotes)
+        val addButton = findViewById<Button>(R.id.buttonAddEvent)
         val saveButton = findViewById<Button>(R.id.buttonSave)
 
         val prefs = getSharedPreferences(javaClass.simpleName, MODE_PRIVATE)
 
         dateEdit.setText(prefs.getString("date", ""))
+        topicEdit.setText(prefs.getString("topic", ""))
         notesEdit.setText(prefs.getString("notes", ""))
+
+        val events = loadEvents(prefs).ifEmpty {
+            mutableListOf(
+                EditorialEvent("1 Jan", "Refleksi Awal Tahun", "Andi", "draft"),
+                EditorialEvent("5 Jan", "Tren Teknologi 2024", "Budi", "review"),
+                EditorialEvent("10 Jan", "Wawancara Tokoh", "Citra", "publish")
+            )
+        }
+
+        val adapter = EditorialCalendarAdapter(events)
+        recyclerView.adapter = adapter
 
         dateEdit.setOnClickListener { showDatePicker(dateEdit) }
 
-        saveButton.setOnClickListener {
+        addButton.setOnClickListener {
+            val eventsList = loadEvents(prefs)
+            val event = EditorialEvent(
+                dateEdit.text.toString(),
+                topicEdit.text.toString(),
+                "",
+                notesEdit.text.toString()
+            )
+            eventsList.add(event)
+            saveEvents(prefs, eventsList)
+            adapter.addItem(event)
             prefs.edit()
                 .putString("date", dateEdit.text.toString())
+                .putString("topic", topicEdit.text.toString())
                 .putString("notes", notesEdit.text.toString())
                 .apply()
         }
 
-        // Sample data to illustrate the calendar design
-        val events = listOf(
-            EditorialEvent("1 Jan", "Refleksi Awal Tahun", "Andi", "draft"),
-            EditorialEvent("5 Jan", "Tren Teknologi 2024", "Budi", "review"),
-            EditorialEvent("10 Jan", "Wawancara Tokoh", "Citra", "publish")
-        )
-
-        recyclerView.adapter = EditorialCalendarAdapter(events)
+        saveButton.setOnClickListener {
+            prefs.edit()
+                .putString("date", dateEdit.text.toString())
+                .putString("topic", topicEdit.text.toString())
+                .putString("notes", notesEdit.text.toString())
+                .apply()
+        }
     }
 
     private fun showDatePicker(target: EditText) {
@@ -59,5 +86,36 @@ class EditorialCalendarActivity : AppCompatActivity() {
             cal.get(Calendar.MONTH),
             cal.get(Calendar.DAY_OF_MONTH)
         ).show()
+    }
+
+    private fun loadEvents(prefs: SharedPreferences): MutableList<EditorialEvent> {
+        val json = prefs.getString("events", "[]") ?: "[]"
+        val array = JSONArray(json)
+        val list = mutableListOf<EditorialEvent>()
+        for (i in 0 until array.length()) {
+            val obj = array.getJSONObject(i)
+            list.add(
+                EditorialEvent(
+                    obj.optString("date"),
+                    obj.optString("topic"),
+                    obj.optString("assignee"),
+                    obj.optString("status")
+                )
+            )
+        }
+        return list
+    }
+
+    private fun saveEvents(prefs: SharedPreferences, events: List<EditorialEvent>) {
+        val array = JSONArray()
+        for (item in events) {
+            val obj = JSONObject()
+            obj.put("date", item.date)
+            obj.put("topic", item.topic)
+            obj.put("assignee", item.assignee)
+            obj.put("status", item.status)
+            array.put(obj)
+        }
+        prefs.edit().putString("events", array.toString()).apply()
     }
 }

--- a/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarAdapter.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarAdapter.kt
@@ -9,7 +9,7 @@ import com.example.penmasnews.R
 import com.example.penmasnews.model.EditorialEvent
 
 class EditorialCalendarAdapter(
-    private val items: List<EditorialEvent>
+    private val items: MutableList<EditorialEvent>
 ) : RecyclerView.Adapter<EditorialCalendarAdapter.ViewHolder>() {
 
     class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
@@ -34,4 +34,9 @@ class EditorialCalendarAdapter(
     }
 
     override fun getItemCount(): Int = items.size
+
+    fun addItem(event: EditorialEvent) {
+        items.add(event)
+        notifyItemInserted(items.size - 1)
+    }
 }

--- a/app/src/main/res/layout/activity_editorial_calendar.xml
+++ b/app/src/main/res/layout/activity_editorial_calendar.xml
@@ -37,10 +37,24 @@
             android:layout_marginTop="16dp" />
 
         <EditText
+            android:id="@+id/editTopic"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_topic"
+            android:layout_marginTop="8dp" />
+
+        <EditText
             android:id="@+id/editNotes"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="@string/hint_notes"
+            android:layout_marginTop="8dp" />
+
+        <Button
+            android:id="@+id/buttonAddEvent"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/action_add"
             android:layout_marginTop="8dp" />
 
         <Button

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,5 +18,7 @@
     <!-- common form hints -->
     <string name="hint_date">Tanggal</string>
     <string name="hint_notes">Catatan</string>
+    <string name="hint_topic">Ide atau Topik</string>
+    <string name="action_add">Tambah</string>
     <string name="action_save">Simpan</string>
 </resources>


### PR DESCRIPTION
## Summary
- add input for topic/idea with hint
- add a new button for adding events
- store topic data in preferences
- persist editorial events in shared preferences

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_687613eee8a08327b1c207111f5894b9