### PR TITLE
Refine editorial calendar form

### DIFF
--- a/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
@@ -24,7 +24,8 @@ class EditorialCalendarActivity : AppCompatActivity() {
 
         val dateEdit = findViewById<EditText>(R.id.editDate)
         val topicEdit = findViewById<EditText>(R.id.editTopic)
-        val notesEdit = findViewById<EditText>(R.id.editNotes)
+        val assigneeEdit = findViewById<EditText>(R.id.editAssignee)
+        val statusEdit = findViewById<EditText>(R.id.editStatus)
         val addButton = findViewById<Button>(R.id.buttonAddEvent)
         val saveButton = findViewById<Button>(R.id.buttonSave)
 
@@ -32,7 +33,8 @@ class EditorialCalendarActivity : AppCompatActivity() {
 
         dateEdit.setText(prefs.getString("date", ""))
         topicEdit.setText(prefs.getString("topic", ""))
-        notesEdit.setText(prefs.getString("notes", ""))
+        assigneeEdit.setText(prefs.getString("assignee", ""))
+        statusEdit.setText(prefs.getString("status", ""))
 
         val events = loadEvents(prefs).ifEmpty {
             mutableListOf(
@@ -52,8 +54,8 @@ class EditorialCalendarActivity : AppCompatActivity() {
             val event = EditorialEvent(
                 dateEdit.text.toString(),
                 topicEdit.text.toString(),
-                "",
-                notesEdit.text.toString()
+                assigneeEdit.text.toString(),
+                statusEdit.text.toString()
             )
             eventsList.add(event)
             saveEvents(prefs, eventsList)
@@ -61,7 +63,8 @@ class EditorialCalendarActivity : AppCompatActivity() {
             prefs.edit()
                 .putString("date", dateEdit.text.toString())
                 .putString("topic", topicEdit.text.toString())
-                .putString("notes", notesEdit.text.toString())
+                .putString("assignee", assigneeEdit.text.toString())
+                .putString("status", statusEdit.text.toString())
                 .apply()
         }
 
@@ -69,7 +72,8 @@ class EditorialCalendarActivity : AppCompatActivity() {
             prefs.edit()
                 .putString("date", dateEdit.text.toString())
                 .putString("topic", topicEdit.text.toString())
-                .putString("notes", notesEdit.text.toString())
+                .putString("assignee", assigneeEdit.text.toString())
+                .putString("status", statusEdit.text.toString())
                 .apply()
         }
     }

--- a/app/src/main/res/layout/activity_editorial_calendar.xml
+++ b/app/src/main/res/layout/activity_editorial_calendar.xml
@@ -44,10 +44,17 @@
             android:layout_marginTop="8dp" />
 
         <EditText
-            android:id="@+id/editNotes"
+            android:id="@+id/editAssignee"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="@string/hint_notes"
+            android:hint="@string/hint_assignee"
+            android:layout_marginTop="8dp" />
+
+        <EditText
+            android:id="@+id/editStatus"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_status"
             android:layout_marginTop="8dp" />
 
         <Button

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,9 +16,11 @@
     <string name="desc_cms_integration">Menyediakan opsi publikasi ke situs web dan berbagai kanal sosial.\nSelesai publikasi, sistem mengarahkan pengguna untuk melihat Analitik.</string>
     <string name="desc_analytics_dashboard">Dashboard metrik performa artikel dan umpan balik pembaca.\nRekomendasi topik baru dapat langsung ditambahkan ke Kalender Editorial.</string>
     <!-- common form hints -->
-    <string name="hint_date">Tanggal</string>
+    <string name="hint_date">Penjadwalan: Tanggal dan waktu publikasi yang direncanakan</string>
     <string name="hint_notes">Catatan</string>
-    <string name="hint_topic">Ide atau Topik</string>
+    <string name="hint_topic">Ide Topik: Catatan singkat tentang gagasan artikel</string>
+    <string name="hint_assignee">Penugasan: Tautan ke penulis, editor, atau tim terkait</string>
+    <string name="hint_status">Status (ide, dalam penulisan, review, siap publish)</string>
     <string name="action_add">Tambah</string>
     <string name="action_save">Simpan</string>
 </resources>

--- a/docs/editorial_calendar.md
+++ b/docs/editorial_calendar.md
@@ -6,10 +6,10 @@ Halaman kalender editorial berfungsi sebagai pusat perencanaan konten.
 
 Modul ini menampilkan kalender harian, mingguan, atau bulanan yang memuat:
 
-- **Ide Topik**: catatan singkat atau link riset.
-- **Penjadwalan**: tanggal dan waktu publikasi.
-- **Penugasan**: reporter/editor yang bertanggung jawab.
-- **Status**: label proses seperti _draft_, _review_, hingga _publish_.
+- **Ide Topik**: Catatan singkat tentang gagasan artikel.
+- **Penjadwalan**: Tanggal dan waktu publikasi yang direncanakan.
+- **Penugasan**: Tautan ke penulis, editor, atau tim terkait.
+- **Status**: Label (misal: ide, dalam penulisan, review, siap publish).
 
 ## Fungsi Utama
 


### PR DESCRIPTION
## Summary
- update UI strings for calendar form
- add assignee and status input fields
- store assignee and status in shared prefs
- document revised field descriptions

## Testing
- `gradlew` not found, no tests run

------
https://chatgpt.com/codex/tasks/task_e_6876220ede248327920c583607c29b0a