### PR TITLE
Add file inputs on AI assistance page

### DIFF
--- a/app/src/main/java/com/example/penmasnews/ui/AIHelperActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/AIHelperActivity.kt
@@ -1,35 +1,58 @@
 package com.example.penmasnews.ui
 
 import android.app.DatePickerDialog
+import android.app.Activity
+import android.content.Intent
 import android.os.Bundle
 import android.widget.Button
 import android.widget.EditText
+import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import com.example.penmasnews.R
 import java.util.Calendar
 
 class AIHelperActivity : AppCompatActivity() {
+    private val pickDoc = 100
+    private val pickPdf = 101
+    private val pickImage = 102
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_ai_helper)
 
         val dateEdit = findViewById<EditText>(R.id.editDate)
         val notesEdit = findViewById<EditText>(R.id.editNotes)
+        val inputEdit = findViewById<EditText>(R.id.editInputText)
+        val docText = findViewById<TextView>(R.id.textDoc)
+        val pdfText = findViewById<TextView>(R.id.textPdf)
+        val imageText = findViewById<TextView>(R.id.textImage)
+        val docButton = findViewById<Button>(R.id.buttonChooseDoc)
+        val pdfButton = findViewById<Button>(R.id.buttonChoosePdf)
+        val imageButton = findViewById<Button>(R.id.buttonChooseImage)
         val saveButton = findViewById<Button>(R.id.buttonSave)
 
         val prefs = getSharedPreferences(javaClass.simpleName, MODE_PRIVATE)
 
         dateEdit.setText(prefs.getString("date", ""))
         notesEdit.setText(prefs.getString("notes", ""))
+        inputEdit.setText(prefs.getString("input", ""))
+        docText.text = prefs.getString("doc", getString(R.string.label_no_file))
+        pdfText.text = prefs.getString("pdf", getString(R.string.label_no_file))
+        imageText.text = prefs.getString("image", getString(R.string.label_no_file))
 
-        dateEdit.setOnClickListener {
-            showDatePicker(dateEdit)
-        }
+        dateEdit.setOnClickListener { showDatePicker(dateEdit) }
+
+        docButton.setOnClickListener { pickFile("application/msword", pickDoc) }
+        pdfButton.setOnClickListener { pickFile("application/pdf", pickPdf) }
+        imageButton.setOnClickListener { pickFile("image/*", pickImage) }
 
         saveButton.setOnClickListener {
             prefs.edit()
                 .putString("date", dateEdit.text.toString())
                 .putString("notes", notesEdit.text.toString())
+                .putString("input", inputEdit.text.toString())
+                .putString("doc", docText.text.toString())
+                .putString("pdf", pdfText.text.toString())
+                .putString("image", imageText.text.toString())
                 .apply()
         }
     }
@@ -46,5 +69,22 @@ class AIHelperActivity : AppCompatActivity() {
             cal.get(Calendar.MONTH),
             cal.get(Calendar.DAY_OF_MONTH)
         ).show()
+    }
+
+    private fun pickFile(type: String, request: Int) {
+        val intent = Intent(Intent.ACTION_GET_CONTENT).apply { this.type = type }
+        startActivityForResult(intent, request)
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (resultCode != Activity.RESULT_OK) return
+        val uri = data?.data ?: return
+        val name = uri.lastPathSegment ?: uri.toString()
+        when (requestCode) {
+            pickDoc -> findViewById<TextView>(R.id.textDoc).text = name
+            pickPdf -> findViewById<TextView>(R.id.textPdf).text = name
+            pickImage -> findViewById<TextView>(R.id.textImage).text = name
+        }
     }
 }

--- a/app/src/main/res/layout/activity_ai_helper.xml
+++ b/app/src/main/res/layout/activity_ai_helper.xml
@@ -37,6 +37,52 @@
             android:hint="@string/hint_notes"
             android:layout_marginTop="8dp" />
 
+        <EditText
+            android:id="@+id/editInputText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_input_text"
+            android:layout_marginTop="8dp" />
+
+        <TextView
+            android:id="@+id/textDoc"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/label_no_file"
+            android:layout_marginTop="8dp" />
+
+        <Button
+            android:id="@+id/buttonChooseDoc"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/button_choose_doc" />
+
+        <TextView
+            android:id="@+id/textPdf"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/label_no_file"
+            android:layout_marginTop="8dp" />
+
+        <Button
+            android:id="@+id/buttonChoosePdf"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/button_choose_pdf" />
+
+        <TextView
+            android:id="@+id/textImage"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/label_no_file"
+            android:layout_marginTop="8dp" />
+
+        <Button
+            android:id="@+id/buttonChooseImage"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/button_choose_image" />
+
         <Button
             android:id="@+id/buttonSave"
             android:layout_width="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,4 +23,9 @@
     <string name="hint_status">Status (ide, dalam penulisan, review, siap publish)</string>
     <string name="action_add">Tambah</string>
     <string name="action_save">Simpan</string>
+    <string name="hint_input_text">Masukan teks</string>
+    <string name="button_choose_doc">Pilih Dokumen</string>
+    <string name="button_choose_pdf">Pilih PDF</string>
+    <string name="button_choose_image">Pilih Gambar</string>
+    <string name="label_no_file">Belum ada file dipilih</string>
 </resources>

--- a/docs/ui_overview.md
+++ b/docs/ui_overview.md
@@ -18,6 +18,7 @@ Dokumen ini memetakan rancangan halaman pada aplikasi Penmas News beserta alur p
 ## 4. Asistensi AI
 - Fitur opsional yang membantu peringkasan, saran judul, dan pengecekan bahasa.
 - Dipanggil dari dalam **Penulisan Kolaboratif** atau dari **Beranda** untuk kebutuhan terpisah.
+- Halaman ini menyediakan kolom masukan teks serta opsi memilih file dokumen, PDF, dan gambar catatan yang akan diproses AI.
 
 ## 5. Manajemen Aset Multimedia
 - Halaman pengunggahan serta katalog gambar, video, dan dokumen.


### PR DESCRIPTION
## Summary
- expand AIHelper activity with text, doc, pdf and image inputs
- persist selected file names in SharedPreferences
- update AI helper layout with new fields
- add Indonesian strings for new fields
- document the additional AI input options

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687624ffce348327a36df1d05e1573ca