### PR TITLE
Refine AI helper flow and collaborative editor

### DIFF
--- a/app/src/main/java/com/example/penmasnews/model/EditorialEvent.kt
+++ b/app/src/main/java/com/example/penmasnews/model/EditorialEvent.kt
@@ -8,5 +8,6 @@ data class EditorialEvent(
     val topic: String,
     val assignee: String,
     val status: String,
-    val content: String = ""
+    val content: String = "",
+    val summary: String = ""
 )

--- a/app/src/main/java/com/example/penmasnews/model/EventStorage.kt
+++ b/app/src/main/java/com/example/penmasnews/model/EventStorage.kt
@@ -20,7 +20,8 @@ object EventStorage {
                     obj.optString("topic"),
                     obj.optString("assignee"),
                     obj.optString("status"),
-                    obj.optString("content")
+                    obj.optString("content"),
+                    obj.optString("summary")
                 )
             )
         }
@@ -36,6 +37,7 @@ object EventStorage {
             obj.put("assignee", item.assignee)
             obj.put("status", item.status)
             obj.put("content", item.content)
+            obj.put("summary", item.summary)
             array.put(obj)
         }
         prefs.edit().putString("events", array.toString()).apply()

--- a/app/src/main/java/com/example/penmasnews/ui/CollaborativeEditorActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/CollaborativeEditorActivity.kt
@@ -1,60 +1,36 @@
 package com.example.penmasnews.ui
 
-import android.app.DatePickerDialog
 import android.os.Bundle
 import android.widget.Button
 import android.widget.EditText
 import androidx.appcompat.app.AppCompatActivity
 import com.example.penmasnews.R
-import java.util.Calendar
 
 class CollaborativeEditorActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_collaborative_editor)
 
-        val dateEdit = findViewById<EditText>(R.id.editDate)
-        val notesEdit = findViewById<EditText>(R.id.editNotes)
+        val titleEdit = findViewById<EditText>(R.id.editTitle)
+        val narrativeEdit = findViewById<EditText>(R.id.editNarrative)
+        val assigneeEdit = findViewById<EditText>(R.id.editAssignee)
+        val statusEdit = findViewById<EditText>(R.id.editStatus)
         val saveButton = findViewById<Button>(R.id.buttonSave)
 
         val prefs = getSharedPreferences(javaClass.simpleName, MODE_PRIVATE)
 
-        val intentDate = intent.getStringExtra("date")
-        val intentNotes = intent.getStringExtra("notes")
-        if (intentDate != null) {
-            dateEdit.setText(intentDate)
-        } else {
-            dateEdit.setText(prefs.getString("date", ""))
-        }
-        if (intentNotes != null) {
-            notesEdit.setText(intentNotes)
-        } else {
-            notesEdit.setText(prefs.getString("notes", ""))
-        }
-
-        dateEdit.setOnClickListener {
-            showDatePicker(dateEdit)
-        }
+        titleEdit.setText(intent.getStringExtra("title") ?: prefs.getString("title", ""))
+        narrativeEdit.setText(intent.getStringExtra("content") ?: prefs.getString("content", ""))
+        assigneeEdit.setText(intent.getStringExtra("assignee") ?: prefs.getString("assignee", ""))
+        statusEdit.setText(intent.getStringExtra("status") ?: prefs.getString("status", ""))
 
         saveButton.setOnClickListener {
             prefs.edit()
-                .putString("date", dateEdit.text.toString())
-                .putString("notes", notesEdit.text.toString())
+                .putString("title", titleEdit.text.toString())
+                .putString("content", narrativeEdit.text.toString())
+                .putString("assignee", assigneeEdit.text.toString())
+                .putString("status", statusEdit.text.toString())
                 .apply()
         }
-    }
-
-    private fun showDatePicker(target: EditText) {
-        val cal = Calendar.getInstance()
-        DatePickerDialog(
-            this,
-            { _, year, month, day ->
-                val result = String.format("%02d-%02d-%04d", day, month + 1, year)
-                target.setText(result)
-            },
-            cal.get(Calendar.YEAR),
-            cal.get(Calendar.MONTH),
-            cal.get(Calendar.DAY_OF_MONTH)
-        ).show()
     }
 }

--- a/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
@@ -44,8 +44,10 @@ class EditorialCalendarActivity : AppCompatActivity() {
         val adapter = EditorialCalendarAdapter(events,
             onOpen = { event ->
                 val intent = android.content.Intent(this, CollaborativeEditorActivity::class.java)
-                intent.putExtra("date", event.date)
-                intent.putExtra("notes", event.content)
+                intent.putExtra("title", event.topic)
+                intent.putExtra("content", event.content)
+                intent.putExtra("assignee", event.assignee)
+                intent.putExtra("status", event.status)
                 startActivity(intent)
             },
             onDelete = { index ->

--- a/app/src/main/res/layout/activity_ai_helper.xml
+++ b/app/src/main/res/layout/activity_ai_helper.xml
@@ -126,7 +126,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/action_generate"
-            android:layout_marginTop="8dp" />
+            android:layout_marginTop="8dp"
+            android:visibility="gone" />
 
         <TextView
             android:id="@+id/textGenerated"
@@ -139,6 +140,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/action_save"
-            android:layout_marginTop="8dp" />
+            android:layout_marginTop="8dp"
+            android:visibility="gone" />
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/activity_collaborative_editor.xml
+++ b/app/src/main/res/layout/activity_collaborative_editor.xml
@@ -16,25 +16,34 @@
             android:layout_height="wrap_content"
             android:paddingBottom="8dp" />
 
-        <TextView
-            android:text="@string/desc_collaborative_editor"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
-
         <EditText
-            android:id="@+id/editDate"
+            android:id="@+id/editTitle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="@string/hint_date"
-            android:focusable="false"
-            android:clickable="true"
+            android:hint="@string/hint_input_text"
             android:layout_marginTop="16dp" />
 
         <EditText
-            android:id="@+id/editNotes"
+            android:id="@+id/editNarrative"
+            android:layout_width="match_parent"
+            android:layout_height="150dp"
+            android:hint="@string/hint_narrative"
+            android:gravity="top"
+            android:inputType="textMultiLine"
+            android:layout_marginTop="8dp" />
+
+        <EditText
+            android:id="@+id/editAssignee"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="@string/hint_notes"
+            android:hint="@string/hint_assignee"
+            android:layout_marginTop="8dp" />
+
+        <EditText
+            android:id="@+id/editStatus"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_status"
             android:layout_marginTop="8dp" />
 
         <Button

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,6 +32,7 @@
     <string name="hint_barang_bukti">Barang Bukti</string>
     <string name="hint_pasal">Pasal yang dipersangkakan</string>
     <string name="hint_ancaman">Ancaman Hukuman</string>
+    <string name="hint_narrative">Narasi Berita</string>
     <string name="hint_add_next_column">Tambahkan kolom selanjutnya</string>
     <string name="action_generate">Generate Berita</string>
     <string name="action_open">Buka Editor</string>


### PR DESCRIPTION
## Summary
- add `summary` field to `EditorialEvent`
- persist summary in `EventStorage`
- adjust AI helper so generate/save buttons appear only when appropriate
- store generated news with summary, default assignee/status, and open calendar
- simplify collaborative editor with new fields for title, narrative, assignee and status

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68766981378c83279548c8206c0fa1f6