### PR TITLE
Separate AI outputs

### DIFF
--- a/app/src/main/res/layout/activity_ai_helper.xml
+++ b/app/src/main/res/layout/activity_ai_helper.xml
@@ -346,19 +346,52 @@
             android:background="?attr/selectableItemBackgroundBorderless"
             android:layout_marginTop="8dp" />
 
-        <Button
-            android:id="@+id/buttonGenerate"
+        <FrameLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/action_generate"
-            android:layout_marginTop="8dp"
-            android:visibility="gone" />
+            android:layout_marginTop="8dp">
 
-        <TextView
-            android:id="@+id/textGenerated"
+            <Button
+                android:id="@+id/buttonGenerate"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/action_generate" />
+
+            <ProgressBar
+                android:id="@+id/progressGenerate"
+                style="?android:attr/progressBarStyleSmall"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:visibility="gone" />
+        </FrameLayout>
+
+        <EditText
+            android:id="@+id/editSuggestedTitle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:hint="@string/hint_suggested_title"
+            android:visibility="gone"
             android:layout_marginTop="8dp" />
+
+        <EditText
+            android:id="@+id/editGeneratedNarrative"
+            android:layout_width="match_parent"
+            android:layout_height="150dp"
+            android:hint="@string/hint_generated_narrative"
+            android:gravity="top"
+            android:inputType="textMultiLine"
+            android:visibility="gone"
+            android:layout_marginTop="8dp" />
+
+        <EditText
+            android:id="@+id/editGeneratedSummary"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_generated_summary"
+            android:visibility="gone"
+            android:layout_marginTop="8dp" />
+
 
         <Button
             android:id="@+id/buttonSave"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,4 +38,7 @@
     <string name="action_open">Buka Editor</string>
     <string name="action_paste">Tempel</string>
     <string name="action_clear">Bersihkan</string>
+    <string name="hint_suggested_title">Saran Judul Berita</string>
+    <string name="hint_generated_narrative">Narasi Hasil AI</string>
+    <string name="hint_generated_summary">Ringkasan Hasil AI</string>
 </resources>


### PR DESCRIPTION
## Summary
- add progress bar to show generation loading state
- display AI suggested title, narrative and summary in separate fields
- save generated content from the new fields

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68767814418c8327b83e81943ed43f81