### PR TITLE
Improve Editorial Calendar UI

### DIFF
--- a/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
@@ -25,8 +25,6 @@ class EditorialCalendarActivity : AppCompatActivity() {
         val assigneeEdit = findViewById<EditText>(R.id.editAssignee)
         val statusEdit = findViewById<EditText>(R.id.editStatus)
         val addButton = findViewById<Button>(R.id.buttonAddEvent)
-        val clearButton = findViewById<Button>(R.id.buttonClearAll)
-        val saveButton = findViewById<Button>(R.id.buttonSave)
 
         val prefs = getSharedPreferences(EventStorage.PREFS_NAME, MODE_PRIVATE)
 
@@ -76,15 +74,6 @@ class EditorialCalendarActivity : AppCompatActivity() {
             statusEdit.text.clear()
         }
 
-        clearButton.setOnClickListener {
-            events.clear()
-            EventStorage.saveEvents(prefs, events)
-            adapter.notifyDataSetChanged()
-        }
-
-        saveButton.setOnClickListener {
-            EventStorage.saveEvents(prefs, events)
-        }
     }
 
     private fun showDatePicker(target: EditText) {

--- a/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarAdapter.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarAdapter.kt
@@ -4,6 +4,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
+import androidx.appcompat.app.AlertDialog
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import com.example.penmasnews.R
@@ -19,8 +20,7 @@ class EditorialCalendarAdapter(
         val dateText: TextView = view.findViewById(R.id.textDate)
         val titleText: TextView = view.findViewById(R.id.textTitle)
         val notesText: TextView = view.findViewById(R.id.textNotes)
-        val openButton: Button = view.findViewById(R.id.buttonOpen)
-        val deleteButton: Button = view.findViewById(R.id.buttonDelete)
+        val actionButton: Button = view.findViewById(R.id.buttonAction)
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
@@ -34,11 +34,28 @@ class EditorialCalendarAdapter(
         holder.dateText.text = item.date
         holder.titleText.text = item.topic
         holder.notesText.text = item.assignee
-        holder.openButton.setOnClickListener { onOpen?.invoke(item) }
-        holder.deleteButton.setOnClickListener {
-            items.removeAt(position)
-            notifyItemRemoved(position)
-            onDelete?.invoke(position)
+
+        holder.itemView.setBackgroundResource(
+            if (position % 2 == 0) R.color.zebra_even else R.color.zebra_odd
+        )
+
+        holder.actionButton.setOnClickListener {
+            AlertDialog.Builder(holder.itemView.context)
+                .setTitle(R.string.dialog_actions)
+                .setItems(arrayOf(
+                    holder.itemView.context.getString(R.string.action_open),
+                    holder.itemView.context.getString(R.string.action_delete)
+                )) { _, which ->
+                    when (which) {
+                        0 -> onOpen?.invoke(item)
+                        1 -> {
+                            items.removeAt(position)
+                            notifyItemRemoved(position)
+                            onDelete?.invoke(position)
+                        }
+                    }
+                }
+                .show()
         }
     }
 

--- a/app/src/main/res/layout/activity_editorial_calendar.xml
+++ b/app/src/main/res/layout/activity_editorial_calendar.xml
@@ -64,18 +64,6 @@
             android:text="@string/action_add"
             android:layout_marginTop="8dp" />
 
-        <Button
-            android:id="@+id/buttonClearAll"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/action_clear"
-            android:layout_marginTop="8dp" />
-
-        <Button
-            android:id="@+id/buttonSave"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/action_save"
-            android:layout_marginTop="8dp" />
+        <!-- Buttons for clearing and saving removed as actions handled per item -->
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/item_editorial_event.xml
+++ b/app/src/main/res/layout/item_editorial_event.xml
@@ -10,37 +10,28 @@
         android:id="@+id/textDate"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textStyle="bold" />
+        android:textStyle="bold"
+        android:textSize="16sp" />
 
     <TextView
         android:id="@+id/textTitle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="2dp" />
+        android:layout_marginTop="2dp"
+        android:textSize="14sp" />
 
     <TextView
         android:id="@+id/textNotes"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="2dp" />
+        android:layout_marginTop="2dp"
+        android:textSize="14sp" />
 
-    <LinearLayout
-        android:orientation="horizontal"
+    <Button
+        android:id="@+id/buttonAction"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="4dp">
-
-        <Button
-            android:id="@+id/buttonOpen"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/action_open" />
-
-        <Button
-            android:id="@+id/buttonDelete"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/action_clear" />
-    </LinearLayout>
+        android:layout_marginTop="4dp"
+        android:text="@string/dialog_actions" />
 
 </LinearLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,0 +1,4 @@
+<resources>
+    <color name="zebra_even">#FFFFFF</color>
+    <color name="zebra_odd">#F5F5F5</color>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,6 +38,8 @@
     <string name="action_open">Buka Editor</string>
     <string name="action_paste">Tempel</string>
     <string name="action_clear">Bersihkan</string>
+    <string name="dialog_actions">Tindakan</string>
+    <string name="action_delete">Hapus List</string>
     <string name="hint_suggested_title">Saran Judul Berita</string>
     <string name="hint_generated_narrative">Narasi Hasil AI</string>
     <string name="hint_generated_summary">Ringkasan Hasil AI</string>


### PR DESCRIPTION
## Summary
- replace per-item action buttons with dialog-based menu
- remove clear/save buttons from the calendar page
- tweak list item layout for clarity and zebra striping
- add supporting strings and colors

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687685a7d3508327b38eb62f0b48ae48