### PR TITLE
Implement approval request flow

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
         <activity android:name=".ui.WorkflowManagerActivity" />
         <activity android:name=".ui.CMSIntegrationActivity" />
         <activity android:name=".ui.AnalyticsDashboardActivity" />
+        <activity android:name=".ui.ApprovalListActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/penmasnews/model/ApprovalStorage.kt
+++ b/app/src/main/java/com/example/penmasnews/model/ApprovalStorage.kt
@@ -1,0 +1,45 @@
+package com.example.penmasnews.model
+
+import android.content.SharedPreferences
+import org.json.JSONArray
+import org.json.JSONObject
+
+/** Utility object for persisting approval requests */
+object ApprovalStorage {
+    const val PREFS_NAME = "approval_requests"
+
+    fun loadEvents(prefs: SharedPreferences): MutableList<EditorialEvent> {
+        val json = prefs.getString("events", "[]") ?: "[]"
+        val array = JSONArray(json)
+        val list = mutableListOf<EditorialEvent>()
+        for (i in 0 until array.length()) {
+            val obj = array.getJSONObject(i)
+            list.add(
+                EditorialEvent(
+                    obj.optString("date"),
+                    obj.optString("topic"),
+                    obj.optString("assignee"),
+                    obj.optString("status"),
+                    obj.optString("content"),
+                    obj.optString("summary")
+                )
+            )
+        }
+        return list
+    }
+
+    fun saveEvents(prefs: SharedPreferences, events: List<EditorialEvent>) {
+        val array = JSONArray()
+        for (item in events) {
+            val obj = JSONObject()
+            obj.put("date", item.date)
+            obj.put("topic", item.topic)
+            obj.put("assignee", item.assignee)
+            obj.put("status", item.status)
+            obj.put("content", item.content)
+            obj.put("summary", item.summary)
+            array.put(obj)
+        }
+        prefs.edit().putString("events", array.toString()).apply()
+    }
+}

--- a/app/src/main/java/com/example/penmasnews/ui/ApprovalListActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/ApprovalListActivity.kt
@@ -1,0 +1,25 @@
+package com.example.penmasnews.ui
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.example.penmasnews.R
+import com.example.penmasnews.model.ApprovalStorage
+import com.example.penmasnews.ui.EditorialCalendarAdapter
+
+class ApprovalListActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_approval_list)
+
+        val recyclerView = findViewById<RecyclerView>(R.id.recyclerViewApproval)
+        recyclerView.layoutManager = LinearLayoutManager(this)
+
+        val prefs = getSharedPreferences(ApprovalStorage.PREFS_NAME, MODE_PRIVATE)
+        val events = ApprovalStorage.loadEvents(prefs)
+
+        val adapter = EditorialCalendarAdapter(events)
+        recyclerView.adapter = adapter
+    }
+}

--- a/app/src/main/java/com/example/penmasnews/ui/CollaborativeEditorActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/CollaborativeEditorActivity.kt
@@ -3,6 +3,10 @@ package com.example.penmasnews.ui
 import android.os.Bundle
 import android.widget.Button
 import android.widget.EditText
+import android.content.Intent
+import com.example.penmasnews.model.EditorialEvent
+import com.example.penmasnews.model.ApprovalStorage
+import com.example.penmasnews.ui.ApprovalListActivity
 import androidx.appcompat.app.AppCompatActivity
 import com.example.penmasnews.R
 
@@ -16,6 +20,7 @@ class CollaborativeEditorActivity : AppCompatActivity() {
         val assigneeEdit = findViewById<EditText>(R.id.editAssignee)
         val statusEdit = findViewById<EditText>(R.id.editStatus)
         val saveButton = findViewById<Button>(R.id.buttonSave)
+        val requestButton = findViewById<Button>(R.id.buttonRequestApproval)
 
         val prefs = getSharedPreferences(javaClass.simpleName, MODE_PRIVATE)
 
@@ -31,6 +36,22 @@ class CollaborativeEditorActivity : AppCompatActivity() {
                 .putString("assignee", assigneeEdit.text.toString())
                 .putString("status", statusEdit.text.toString())
                 .apply()
+        }
+
+        requestButton.setOnClickListener {
+            val prefsApproval = getSharedPreferences(ApprovalStorage.PREFS_NAME, MODE_PRIVATE)
+            val approvals = ApprovalStorage.loadEvents(prefsApproval)
+            approvals.add(
+                EditorialEvent(
+                    "",
+                    titleEdit.text.toString(),
+                    assigneeEdit.text.toString(),
+                    statusEdit.text.toString(),
+                    narrativeEdit.text.toString()
+                )
+            )
+            ApprovalStorage.saveEvents(prefsApproval, approvals)
+            startActivity(Intent(this, ApprovalListActivity::class.java))
         }
     }
 }

--- a/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarAdapter.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarAdapter.kt
@@ -3,7 +3,7 @@ package com.example.penmasnews.ui
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Button
+import android.widget.ImageButton
 import androidx.appcompat.app.AlertDialog
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
@@ -20,7 +20,7 @@ class EditorialCalendarAdapter(
         val dateText: TextView = view.findViewById(R.id.textDate)
         val titleText: TextView = view.findViewById(R.id.textTitle)
         val notesText: TextView = view.findViewById(R.id.textNotes)
-        val actionButton: Button = view.findViewById(R.id.buttonAction)
+        val actionButton: ImageButton = view.findViewById(R.id.buttonAction)
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {

--- a/app/src/main/res/layout/activity_approval_list.xml
+++ b/app/src/main/res/layout/activity_approval_list.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp">
+
+    <TextView
+        android:text="@string/feature_workflow_approval"
+        android:textSize="20sp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingBottom="8dp" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerViewApproval"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</LinearLayout>

--- a/app/src/main/res/layout/activity_collaborative_editor.xml
+++ b/app/src/main/res/layout/activity_collaborative_editor.xml
@@ -26,7 +26,7 @@
         <EditText
             android:id="@+id/editNarrative"
             android:layout_width="match_parent"
-            android:layout_height="150dp"
+            android:layout_height="300dp"
             android:hint="@string/hint_narrative"
             android:gravity="top"
             android:inputType="textMultiLine"
@@ -46,11 +46,25 @@
             android:hint="@string/hint_status"
             android:layout_marginTop="8dp" />
 
-        <Button
-            android:id="@+id/buttonSave"
-            android:layout_width="wrap_content"
+        <LinearLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/action_save"
-            android:layout_marginTop="8dp" />
+            android:orientation="horizontal"
+            android:layout_marginTop="8dp">
+
+            <Button
+                android:id="@+id/buttonSave"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/action_save" />
+
+            <Button
+                android:id="@+id/buttonRequestApproval"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/action_request_approval" />
+        </LinearLayout>
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/item_editorial_event.xml
+++ b/app/src/main/res/layout/item_editorial_event.xml
@@ -1,10 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical"
+    android:orientation="horizontal"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:padding="8dp"
     android:background="@android:color/white">
+
+    <LinearLayout
+        android:orientation="vertical"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1">
 
     <TextView
         android:id="@+id/textDate"
@@ -27,11 +33,14 @@
         android:layout_marginTop="2dp"
         android:textSize="14sp" />
 
-    <Button
+    </LinearLayout>
+
+    <ImageButton
         android:id="@+id/buttonAction"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="4dp"
-        android:text="@string/dialog_actions" />
+        android:src="@android:drawable/ic_menu_send"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:contentDescription="@string/dialog_actions" />
 
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,4 +43,5 @@
     <string name="hint_suggested_title">Saran Judul Berita</string>
     <string name="hint_generated_narrative">Narasi Hasil AI</string>
     <string name="hint_generated_summary">Ringkasan Hasil AI</string>
+    <string name="action_request_approval">Minta Persetujuan</string>
 </resources>


### PR DESCRIPTION
## Summary
- replace editorial calendar item actions with a send icon
- enlarge collaborative narrative field and add *Minta Persetujuan* button
- store approval requests and show them in a new Approval page

## Testing
- `./gradlew test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68768971cd4c83279d2d80f50ccd6ea9