### PR TITLE
Add image grid to asset manager

### DIFF
--- a/app/src/main/java/com/example/penmasnews/ui/AssetGridAdapter.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/AssetGridAdapter.kt
@@ -1,0 +1,29 @@
+package com.example.penmasnews.ui
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import androidx.recyclerview.widget.RecyclerView
+import com.example.penmasnews.R
+
+class AssetGridAdapter(
+    private val items: List<Int>
+) : RecyclerView.Adapter<AssetGridAdapter.ViewHolder>() {
+
+    class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+        val image: ImageView = view.findViewById(R.id.imageAsset)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.item_asset_image, parent, false)
+        return ViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.image.setImageResource(items[position])
+    }
+
+    override fun getItemCount(): Int = items.size
+}

--- a/app/src/main/java/com/example/penmasnews/ui/AssetManagerActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/AssetManagerActivity.kt
@@ -1,50 +1,21 @@
 package com.example.penmasnews.ui
 
-import android.app.DatePickerDialog
 import android.os.Bundle
-import android.widget.Button
-import android.widget.EditText
 import androidx.appcompat.app.AppCompatActivity
+import androidx.recyclerview.widget.GridLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.example.penmasnews.R
-import java.util.Calendar
 
 class AssetManagerActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_asset_manager)
 
-        val dateEdit = findViewById<EditText>(R.id.editDate)
-        val notesEdit = findViewById<EditText>(R.id.editNotes)
-        val saveButton = findViewById<Button>(R.id.buttonSave)
+        val recyclerView = findViewById<RecyclerView>(R.id.recyclerViewAssets)
+        recyclerView.layoutManager = GridLayoutManager(this, 3)
 
-        val prefs = getSharedPreferences(javaClass.simpleName, MODE_PRIVATE)
-
-        dateEdit.setText(prefs.getString("date", ""))
-        notesEdit.setText(prefs.getString("notes", ""))
-
-        dateEdit.setOnClickListener {
-            showDatePicker(dateEdit)
-        }
-
-        saveButton.setOnClickListener {
-            prefs.edit()
-                .putString("date", dateEdit.text.toString())
-                .putString("notes", notesEdit.text.toString())
-                .apply()
-        }
-    }
-
-    private fun showDatePicker(target: EditText) {
-        val cal = Calendar.getInstance()
-        DatePickerDialog(
-            this,
-            { _, year, month, day ->
-                val result = String.format("%02d-%02d-%04d", day, month + 1, year)
-                target.setText(result)
-            },
-            cal.get(Calendar.YEAR),
-            cal.get(Calendar.MONTH),
-            cal.get(Calendar.DAY_OF_MONTH)
-        ).show()
+        val images = List(9) { android.R.drawable.ic_menu_gallery }
+        val adapter = AssetGridAdapter(images)
+        recyclerView.adapter = adapter
     }
 }

--- a/app/src/main/res/layout/activity_asset_manager.xml
+++ b/app/src/main/res/layout/activity_asset_manager.xml
@@ -1,58 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:padding="16dp">
 
-    <LinearLayout
-        android:orientation="vertical"
+    <TextView
+        android:text="@string/feature_asset_management"
+        android:textSize="20sp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingBottom="8dp" />
+
+    <TextView
+        android:text="@string/desc_asset_manager"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="16dp">
+        android:paddingBottom="16dp"
+        android:lineSpacingExtra="2dp" />
 
-        <TextView
-            android:text="@string/feature_asset_management"
-            android:textSize="20sp"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingBottom="8dp" />
-
-        <TextView
-            android:text="@string/desc_asset_manager"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:lineSpacingExtra="2dp" />
-
-        <com.google.android.material.textfield.TextInputLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="@string/hint_date"
-            android:layout_marginTop="16dp">
-
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/editDate"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:focusable="false"
-                android:clickable="true" />
-        </com.google.android.material.textfield.TextInputLayout>
-
-        <com.google.android.material.textfield.TextInputLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="@string/hint_notes"
-            android:layout_marginTop="8dp">
-
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/editNotes"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
-        </com.google.android.material.textfield.TextInputLayout>
-
-        <Button
-            android:id="@+id/buttonSave"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/action_save"
-            android:layout_marginTop="8dp" />
-    </LinearLayout>
-</ScrollView>
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerViewAssets"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@drawable/list_border"
+        android:padding="4dp" />
+</LinearLayout>

--- a/app/src/main/res/layout/item_asset_image.xml
+++ b/app/src/main/res/layout/item_asset_image.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="4dp">
+
+    <ImageView
+        android:id="@+id/imageAsset"
+        android:layout_width="match_parent"
+        android:layout_height="100dp"
+        android:scaleType="centerCrop"
+        android:src="@android:drawable/ic_menu_gallery" />
+</FrameLayout>


### PR DESCRIPTION
## Summary
- switch asset manager to display a grid of dummy images
- remove old date and notes input fields
- add a RecyclerView adapter for the dummy assets

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876ee00151c8327bcb1689fd4527de7