### PR TITLE
Fix AI assist page generate workflow

### DIFF
--- a/app/src/main/java/com/example/penmasnews/ui/AIHelperActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/AIHelperActivity.kt
@@ -37,6 +37,7 @@ class AIHelperActivity : AppCompatActivity() {
         val dateEdit = findViewById<EditText>(R.id.editDate)
         val notesEdit = findViewById<EditText>(R.id.editNotes)
         val inputEdit = findViewById<EditText>(R.id.editInputText)
+        val layoutInput = findViewById<android.view.View>(R.id.layoutInputText)
         val dasarEdit = findViewById<EditText>(R.id.editDasar)
         val tersangkaEdit = findViewById<EditText>(R.id.editTersangka)
         val tkpEdit = findViewById<EditText>(R.id.editTKP)
@@ -119,7 +120,7 @@ class AIHelperActivity : AppCompatActivity() {
         val layoutNotes = findViewById<android.view.View>(R.id.layoutNotes)
 
         val fields = listOf<android.view.View>(
-            inputEdit,
+            layoutInput,
             layoutDasar,
             layoutTersangka,
             layoutTKP,
@@ -145,7 +146,7 @@ class AIHelperActivity : AppCompatActivity() {
         )
 
         fun checkReady() {
-            val ready = textFields.all { it.visibility == android.view.View.VISIBLE && it.text.isNotBlank() }
+            val ready = textFields.all { it.isShown && it.text.isNotBlank() }
             generateButton.visibility = if (ready) android.view.View.VISIBLE else android.view.View.GONE
         }
         textFields.forEach { field ->

--- a/app/src/main/res/layout/activity_ai_helper.xml
+++ b/app/src/main/res/layout/activity_ai_helper.xml
@@ -45,6 +45,7 @@
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/layoutInputText"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="@string/hint_input_text"


### PR DESCRIPTION
## Summary
- fix layout id to reveal input field container
- show generate button only when all visible fields are filled
- include layout container for first field so columns appear correctly

## Testing
- `gradle help --task assembleDebug`

------
https://chatgpt.com/codex/tasks/task_e_68772058f928832786b05823619e25e5