### PR TITLE
Add news type spinner to AI helper

### DIFF
--- a/app/src/main/res/layout/activity_ai_helper.xml
+++ b/app/src/main/res/layout/activity_ai_helper.xml
@@ -58,6 +58,15 @@
                 android:layout_height="wrap_content" />
         </com.google.android.material.textfield.TextInputLayout>
 
+        <Spinner
+            android:id="@+id/spinnerType"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:entries="@array/news_type_array"
+            android:prompt="@string/label_news_type"
+            android:layout_marginTop="8dp"
+            android:visibility="gone" />
+
         <LinearLayout
             android:id="@+id/layoutDasar"
             android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,4 +44,9 @@
     <string name="hint_generated_narrative">Narasi Hasil AI</string>
     <string name="hint_generated_summary">Ringkasan Hasil AI</string>
     <string name="action_request_approval">Approval</string>
+    <string name="label_news_type">Jenis Konten</string>
+    <string-array name="news_type_array">
+        <item>Pers Release</item>
+        <item>Berita Online</item>
+    </string-array>
 </resources>


### PR DESCRIPTION
## Summary
- add new `news_type_array` to choose between Press Release and Berita Online
- show spinner under the Judul Berita field
- update `AIHelperActivity` to switch fields based on spinner choice
- generate different prompts for Berita Online

## Testing
- `gradle build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68772807e2908327bd5549c712d452bb