### PR TITLE
Fix AIHelper output visibility

### DIFF
--- a/app/src/main/java/com/example/penmasnews/ui/AIHelperActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/AIHelperActivity.kt
@@ -105,6 +105,9 @@ class AIHelperActivity : AppCompatActivity() {
         val titleOutput = findViewById<EditText>(R.id.editSuggestedTitle)
         val narrativeOutput = findViewById<EditText>(R.id.editGeneratedNarrative)
         val summaryOutput = findViewById<EditText>(R.id.editGeneratedSummary)
+        val layoutSuggestedTitle = findViewById<android.view.View>(R.id.layoutSuggestedTitle)
+        val layoutGeneratedNarrative = findViewById<android.view.View>(R.id.layoutGeneratedNarrative)
+        val layoutGeneratedSummary = findViewById<android.view.View>(R.id.layoutGeneratedSummary)
         val saveButton = findViewById<Button>(R.id.buttonSave)
 
         val prefs = getSharedPreferences(EventStorage.PREFS_NAME, MODE_PRIVATE)
@@ -363,9 +366,9 @@ class AIHelperActivity : AppCompatActivity() {
                         titleOutput.setText(title)
                         narrativeOutput.setText(narrative)
                         summaryOutput.setText(summary)
-                        titleOutput.visibility = android.view.View.VISIBLE
-                        narrativeOutput.visibility = android.view.View.VISIBLE
-                        summaryOutput.visibility = android.view.View.VISIBLE
+                        layoutSuggestedTitle.visibility = android.view.View.VISIBLE
+                        layoutGeneratedNarrative.visibility = android.view.View.VISIBLE
+                        layoutGeneratedSummary.visibility = android.view.View.VISIBLE
                         saveButton.visibility = android.view.View.VISIBLE
                     }
                 } catch (e: Exception) {
@@ -408,9 +411,9 @@ class AIHelperActivity : AppCompatActivity() {
             titleOutput.setText("")
             narrativeOutput.setText("")
             summaryOutput.setText("")
-            titleOutput.visibility = android.view.View.GONE
-            narrativeOutput.visibility = android.view.View.GONE
-            summaryOutput.visibility = android.view.View.GONE
+            layoutSuggestedTitle.visibility = android.view.View.GONE
+            layoutGeneratedNarrative.visibility = android.view.View.GONE
+            layoutGeneratedSummary.visibility = android.view.View.GONE
             generateButton.visibility = android.view.View.GONE
             saveButton.visibility = android.view.View.GONE
             val intent = android.content.Intent(this, EditorialCalendarActivity::class.java)

--- a/app/src/main/res/layout/activity_ai_helper.xml
+++ b/app/src/main/res/layout/activity_ai_helper.xml
@@ -441,6 +441,7 @@
         </FrameLayout>
 
         <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/layoutSuggestedTitle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="@string/hint_suggested_title"
@@ -454,6 +455,7 @@
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/layoutGeneratedNarrative"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="@string/hint_generated_narrative"
@@ -469,6 +471,7 @@
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/layoutGeneratedSummary"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="@string/hint_generated_summary"


### PR DESCRIPTION
## Summary
- add layout IDs for title, narrative, and summary result fields
- show/hide those layouts when generating and saving news

## Testing
- `gradle tasks`

------
https://chatgpt.com/codex/tasks/task_e_6877300ca4a8832784edbde3ef8f6ae7