### PR TITLE
Add simple login screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ This repository contains a minimal Android application skeleton written in Kotli
 It demonstrates the core structure for a news production workflow app. Several
 features are represented as placeholder classes.
 
+When the app starts you will be presented with a simple login screen. Use the
+credentials `@papiqo` and password `12345` to log in as the `penulis` actor.
+
 ## Building the App
 
 This project uses Gradle. Because the Android SDK isn't bundled in this

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,12 +7,13 @@
         android:allowBackup="true"
         android:label="@string/app_name"
         android:theme="@style/Theme.MaterialComponents.DayNight.DarkActionBar">
-        <activity android:name=".MainActivity" android:exported="true">
+        <activity android:name=".ui.LoginActivity" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".MainActivity" android:exported="true" />
         <activity android:name=".ui.EditorialCalendarActivity" />
         <activity android:name=".ui.CollaborativeEditorActivity" />
         <activity android:name=".ui.AIHelperActivity" />

--- a/app/src/main/java/com/example/penmasnews/MainActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/MainActivity.kt
@@ -3,6 +3,7 @@ package com.example.penmasnews
 import android.content.Intent
 import android.os.Bundle
 import android.widget.Button
+import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import com.example.penmasnews.ui.AIHelperActivity
 import com.example.penmasnews.ui.AnalyticsDashboardActivity
@@ -16,6 +17,11 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        intent.getStringExtra("actor")?.let { role ->
+            val helloText = findViewById<TextView>(R.id.helloText)
+            helloText.text = getString(R.string.hello_actor, role)
+        }
 
         findViewById<Button>(R.id.buttonEditorialCalendar).setOnClickListener {
             startActivity(Intent(this, EditorialCalendarActivity::class.java))

--- a/app/src/main/java/com/example/penmasnews/ui/LoginActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/LoginActivity.kt
@@ -1,0 +1,34 @@
+package com.example.penmasnews.ui
+
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Button
+import android.widget.EditText
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import com.example.penmasnews.MainActivity
+import com.example.penmasnews.R
+
+class LoginActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_login)
+
+        val editUsername = findViewById<EditText>(R.id.editUsername)
+        val editPassword = findViewById<EditText>(R.id.editPassword)
+        val buttonLogin = findViewById<Button>(R.id.buttonLogin)
+
+        buttonLogin.setOnClickListener {
+            val username = editUsername.text.toString()
+            val password = editPassword.text.toString()
+            if (username == "@papiqo" && password == "12345") {
+                val intent = Intent(this, MainActivity::class.java)
+                intent.putExtra("actor", "penulis")
+                startActivity(intent)
+                finish()
+            } else {
+                Toast.makeText(this, R.string.error_login, Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp">
+
+    <EditText
+        android:id="@+id/editUsername"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/hint_username" />
+
+    <EditText
+        android:id="@+id/editPassword"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/hint_password"
+        android:inputType="textPassword"
+        android:layout_marginTop="8dp" />
+
+    <Button
+        android:id="@+id/buttonLogin"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/action_login"
+        android:layout_marginTop="16dp" />
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,4 +49,9 @@
         <item>Pers Release</item>
         <item>Berita Online</item>
     </string-array>
+    <string name="hint_username">Username</string>
+    <string name="hint_password">Password</string>
+    <string name="action_login">Login</string>
+    <string name="error_login">Login gagal</string>
+    <string name="hello_actor">Halo, %1$s</string>
 </resources>


### PR DESCRIPTION
## Summary
- introduce `LoginActivity` for demo authentication
- set login as launcher activity in manifest
- show logged-in actor in main screen
- document demo credentials in README

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877365eb5448327b78548b5b4fc1aa8