### PR TITLE
Fix RecyclerView deletion index error

### DIFF
--- a/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
@@ -48,8 +48,7 @@ class EditorialCalendarActivity : AppCompatActivity() {
                 intent.putExtra("status", event.status)
                 startActivity(intent)
             },
-            onDelete = { index ->
-                events.removeAt(index)
+            onDelete = { _ ->
                 EventStorage.saveEvents(prefs, events)
             }
         )


### PR DESCRIPTION
## Summary
- update `onDelete` callback to avoid double removal in `EditorialCalendarActivity`

## Testing
- `./gradlew test` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877393194c883278dbd976e9620bc73