### PR TITLE
Add update logs for collaborative editing

### DIFF
--- a/app/src/main/java/com/example/penmasnews/model/ChangeLogEntry.kt
+++ b/app/src/main/java/com/example/penmasnews/model/ChangeLogEntry.kt
@@ -1,0 +1,9 @@
+package com.example.penmasnews.model
+
+/** Data class capturing an edit log entry */
+data class ChangeLogEntry(
+    val user: String,
+    val status: String,
+    val changes: String,
+    val timestamp: Long
+)

--- a/app/src/main/java/com/example/penmasnews/model/ChangeLogStorage.kt
+++ b/app/src/main/java/com/example/penmasnews/model/ChangeLogStorage.kt
@@ -1,0 +1,41 @@
+package com.example.penmasnews.model
+
+import android.content.SharedPreferences
+import org.json.JSONArray
+import org.json.JSONObject
+
+/** Utility object for persisting change log entries */
+object ChangeLogStorage {
+    const val PREFS_NAME = "change_logs"
+
+    fun loadLogs(prefs: SharedPreferences): MutableList<ChangeLogEntry> {
+        val json = prefs.getString("logs", "[]") ?: "[]"
+        val array = JSONArray(json)
+        val list = mutableListOf<ChangeLogEntry>()
+        for (i in 0 until array.length()) {
+            val obj = array.getJSONObject(i)
+            list.add(
+                ChangeLogEntry(
+                    obj.optString("user"),
+                    obj.optString("status"),
+                    obj.optString("changes"),
+                    obj.optLong("timestamp")
+                )
+            )
+        }
+        return list
+    }
+
+    fun saveLogs(prefs: SharedPreferences, logs: List<ChangeLogEntry>) {
+        val array = JSONArray()
+        for (log in logs) {
+            val obj = JSONObject()
+            obj.put("user", log.user)
+            obj.put("status", log.status)
+            obj.put("changes", log.changes)
+            obj.put("timestamp", log.timestamp)
+            array.put(obj)
+        }
+        prefs.edit().putString("logs", array.toString()).apply()
+    }
+}

--- a/app/src/main/java/com/example/penmasnews/ui/CollaborativeEditorActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/CollaborativeEditorActivity.kt
@@ -4,16 +4,23 @@ import android.os.Bundle
 import android.widget.Button
 import android.widget.EditText
 import android.widget.ImageView
+import android.widget.TextView
 import android.content.Intent
 import java.io.File
 import com.example.penmasnews.model.EditorialEvent
 import com.example.penmasnews.model.ApprovalStorage
+import com.example.penmasnews.model.ChangeLogEntry
+import com.example.penmasnews.model.ChangeLogStorage
 import com.example.penmasnews.ui.ApprovalListActivity
 import androidx.appcompat.app.AppCompatActivity
 import com.example.penmasnews.R
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 class CollaborativeEditorActivity : AppCompatActivity() {
     private lateinit var imageView: ImageView
+    private lateinit var logText: TextView
     private var imagePath: String? = null
     companion object { private const val REQUEST_IMAGE = 2001 }
 
@@ -26,10 +33,14 @@ class CollaborativeEditorActivity : AppCompatActivity() {
         val assigneeEdit = findViewById<EditText>(R.id.editAssignee)
         val statusEdit = findViewById<EditText>(R.id.editStatus)
         imageView = findViewById(R.id.imageCollab)
+        logText = findViewById(R.id.textLogs)
         val saveButton = findViewById<Button>(R.id.buttonSave)
         val requestButton = findViewById<Button>(R.id.buttonRequestApproval)
 
         val prefs = getSharedPreferences(javaClass.simpleName, MODE_PRIVATE)
+        val logPrefs = getSharedPreferences(ChangeLogStorage.PREFS_NAME, MODE_PRIVATE)
+        val changeLogs = ChangeLogStorage.loadLogs(logPrefs)
+        displayLogs(changeLogs)
 
         imagePath = prefs.getString("imagePath", null)
         imagePath?.let { path ->
@@ -47,6 +58,12 @@ class CollaborativeEditorActivity : AppCompatActivity() {
         statusEdit.setText(intent.getStringExtra("status") ?: prefs.getString("status", ""))
 
         saveButton.setOnClickListener {
+            val oldTitle = prefs.getString("title", "")
+            val oldContent = prefs.getString("content", "")
+            val oldAssignee = prefs.getString("assignee", "")
+            val oldStatus = prefs.getString("status", "")
+            val oldImage = prefs.getString("imagePath", "")
+
             prefs.edit()
                 .putString("title", titleEdit.text.toString())
                 .putString("content", narrativeEdit.text.toString())
@@ -54,6 +71,21 @@ class CollaborativeEditorActivity : AppCompatActivity() {
                 .putString("status", statusEdit.text.toString())
                 .putString("imagePath", imagePath ?: "")
                 .apply()
+
+            val changed = mutableListOf<String>()
+            if (oldTitle != titleEdit.text.toString()) changed.add("title")
+            if (oldContent != narrativeEdit.text.toString()) changed.add("content")
+            if (oldAssignee != assigneeEdit.text.toString()) changed.add("assignee")
+            if (oldStatus != statusEdit.text.toString()) changed.add("status")
+            if (oldImage != (imagePath ?: "")) changed.add("image")
+
+            val changesDesc = if (changed.isEmpty()) "no change" else changed.joinToString(", ")
+            val userPrefs = getSharedPreferences("user", MODE_PRIVATE)
+            val user = userPrefs.getString("username", "unknown") ?: "unknown"
+            val entry = ChangeLogEntry(user, statusEdit.text.toString(), changesDesc, System.currentTimeMillis())
+            changeLogs.add(entry)
+            ChangeLogStorage.saveLogs(logPrefs, changeLogs)
+            displayLogs(changeLogs)
         }
 
         requestButton.setOnClickListener {
@@ -87,6 +119,13 @@ class CollaborativeEditorActivity : AppCompatActivity() {
                 }
             }
             imagePath = File(filesDir, fileName).absolutePath
+        }
+    }
+
+    private fun displayLogs(logs: List<ChangeLogEntry>) {
+        val df = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
+        logText.text = logs.joinToString("\n") {
+            "${df.format(Date(it.timestamp))} - ${it.user} - ${it.status} - ${it.changes}"
         }
     }
 }

--- a/app/src/main/java/com/example/penmasnews/ui/LoginActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/LoginActivity.kt
@@ -24,6 +24,8 @@ class LoginActivity : AppCompatActivity() {
             if (username == "@papiqo" && password == "12345") {
                 val intent = Intent(this, MainActivity::class.java)
                 intent.putExtra("actor", "penulis")
+                getSharedPreferences("user", MODE_PRIVATE)
+                    .edit().putString("username", username).apply()
                 startActivity(intent)
                 finish()
             } else {

--- a/app/src/main/res/layout/activity_collaborative_editor.xml
+++ b/app/src/main/res/layout/activity_collaborative_editor.xml
@@ -73,6 +73,21 @@
                 android:layout_height="wrap_content" />
         </com.google.android.material.textfield.TextInputLayout>
 
+        <TextView
+            android:id="@+id/textLogHeader"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/label_change_log"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/textLogs"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textSize="12sp"
+            android:layout_marginTop="4dp" />
+
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -84,7 +99,7 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
-                android:text="@string/action_save" />
+                android:text="@string/action_update" />
 
             <Button
                 android:id="@+id/buttonRequestApproval"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,6 +23,8 @@
     <string name="hint_status">Status (ide, dalam penulisan, review, siap publish)</string>
     <string name="action_add">Tambah</string>
     <string name="action_save">Simpan</string>
+    <string name="action_update">Update</string>
+    <string name="label_change_log">Log Perubahan</string>
     <string name="hint_input_text">Judul Berita</string>
     <string name="hint_dasar">Dasar</string>
     <string name="hint_tersangka">Tersangka</string>


### PR DESCRIPTION
## Summary
- update login to remember username
- add model and storage for collaborative change logs
- show log section in collaborative editor
- change save button text to *Update*
- log data modifications when saving in collaborative editor

## Testing
- `gradle build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68773b7ea0c483278f227c19ef40858d