### PR TITLE
Implement logs for additional pages

### DIFF
--- a/app/src/main/java/com/example/penmasnews/ui/AIHelperActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/AIHelperActivity.kt
@@ -15,6 +15,8 @@ import android.text.TextWatcher
 import com.example.penmasnews.BuildConfig
 import com.example.penmasnews.model.EditorialEvent
 import com.example.penmasnews.model.EventStorage
+import com.example.penmasnews.model.ChangeLogEntry
+import com.example.penmasnews.model.ChangeLogStorage
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -395,6 +397,21 @@ class AIHelperActivity : AppCompatActivity() {
             )
             events.add(event)
             EventStorage.saveEvents(prefs, events)
+            // log save of AI generated content
+            val logPrefs = getSharedPreferences(ChangeLogStorage.PREFS_NAME, MODE_PRIVATE)
+            val logs = ChangeLogStorage.loadLogs(logPrefs)
+            val userPrefs = getSharedPreferences("user", MODE_PRIVATE)
+            val user = userPrefs.getString("username", "unknown") ?: "unknown"
+            val changesDesc = listOf("ai_generated", "date", "title").joinToString(", ")
+            logs.add(
+                ChangeLogEntry(
+                    user,
+                    event.status,
+                    changesDesc,
+                    System.currentTimeMillis()
+                )
+            )
+            ChangeLogStorage.saveLogs(logPrefs, logs)
             dateEdit.text.clear()
             inputEdit.text.clear()
             dasarEdit.text.clear()

--- a/app/src/main/java/com/example/penmasnews/ui/ApprovalListAdapter.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/ApprovalListAdapter.kt
@@ -8,6 +8,8 @@ import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import com.example.penmasnews.R
 import com.example.penmasnews.model.EditorialEvent
+import com.example.penmasnews.model.ChangeLogEntry
+import com.example.penmasnews.model.ChangeLogStorage
 
 class ApprovalListAdapter(
     private val items: MutableList<EditorialEvent>,
@@ -35,12 +37,40 @@ class ApprovalListAdapter(
         holder.approveButton.setOnClickListener {
             item.status = "disetujui"
             notifyItemChanged(position)
+            val context = holder.itemView.context
+            val logPrefs = context.getSharedPreferences(ChangeLogStorage.PREFS_NAME, android.content.Context.MODE_PRIVATE)
+            val logs = ChangeLogStorage.loadLogs(logPrefs)
+            val userPrefs = context.getSharedPreferences("user", android.content.Context.MODE_PRIVATE)
+            val user = userPrefs.getString("username", "unknown") ?: "unknown"
+            logs.add(
+                ChangeLogEntry(
+                    user,
+                    item.status,
+                    "workflow approve",
+                    System.currentTimeMillis()
+                )
+            )
+            ChangeLogStorage.saveLogs(logPrefs, logs)
             onStatusChanged?.invoke()
         }
 
         holder.rejectButton.setOnClickListener {
             item.status = "revisi"
             notifyItemChanged(position)
+            val context = holder.itemView.context
+            val logPrefs = context.getSharedPreferences(ChangeLogStorage.PREFS_NAME, android.content.Context.MODE_PRIVATE)
+            val logs = ChangeLogStorage.loadLogs(logPrefs)
+            val userPrefs = context.getSharedPreferences("user", android.content.Context.MODE_PRIVATE)
+            val user = userPrefs.getString("username", "unknown") ?: "unknown"
+            logs.add(
+                ChangeLogEntry(
+                    user,
+                    item.status,
+                    "workflow reject",
+                    System.currentTimeMillis()
+                )
+            )
+            ChangeLogStorage.saveLogs(logPrefs, logs)
             onStatusChanged?.invoke()
         }
     }

--- a/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
@@ -5,6 +5,8 @@ import android.os.Bundle
 import android.widget.Button
 import android.widget.EditText
 import com.example.penmasnews.model.EventStorage
+import com.example.penmasnews.model.ChangeLogEntry
+import com.example.penmasnews.model.ChangeLogStorage
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -66,6 +68,21 @@ class EditorialCalendarActivity : AppCompatActivity() {
             )
             eventsList.add(event)
             EventStorage.saveEvents(prefs, eventsList)
+            // log creation of new calendar event
+            val logPrefs = getSharedPreferences(ChangeLogStorage.PREFS_NAME, MODE_PRIVATE)
+            val logs = ChangeLogStorage.loadLogs(logPrefs)
+            val userPrefs = getSharedPreferences("user", MODE_PRIVATE)
+            val user = userPrefs.getString("username", "unknown") ?: "unknown"
+            val changesDesc = listOf("date", "topic", "assignee", "status").joinToString(", ")
+            logs.add(
+                ChangeLogEntry(
+                    user,
+                    event.status,
+                    changesDesc,
+                    System.currentTimeMillis()
+                )
+            )
+            ChangeLogStorage.saveLogs(logPrefs, logs)
             adapter.addItem(event)
             dateEdit.text.clear()
             topicEdit.text.clear()


### PR DESCRIPTION
## Summary
- add change log imports to activities and adapters
- capture change log entries when saving editorial calendar entries
- log AI helper save events
- log workflow approval status changes

## Testing
- `gradle tasks`
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68773e5e152883279ff92da0078858b0