### PR TITLE
Add AI assist menu and share event data

### DIFF
--- a/app/src/main/java/com/example/penmasnews/ui/AIHelperActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/AIHelperActivity.kt
@@ -70,6 +70,12 @@ class AIHelperActivity : AppCompatActivity() {
         val pasteNotes = findViewById<ImageButton>(R.id.buttonPasteNotes)
         val clearNotes = findViewById<ImageButton>(R.id.buttonClearNotes)
 
+        val index = intent.getIntExtra("index", -1)
+        val extrasDate = intent.getStringExtra("date")
+        val extrasTitle = intent.getStringExtra("title")
+        extrasDate?.let { dateEdit.setText(it) }
+        extrasTitle?.let { inputEdit.setText(it) }
+
         imageView.setOnClickListener {
             val intent = Intent(Intent.ACTION_GET_CONTENT)
             intent.type = "image/*"
@@ -395,7 +401,11 @@ class AIHelperActivity : AppCompatActivity() {
                 summaryOutput.text.toString(),
                 selectedImagePath ?: ""
             )
-            events.add(event)
+            if (index >= 0 && index < events.size) {
+                events[index] = event
+            } else {
+                events.add(event)
+            }
             EventStorage.saveEvents(prefs, events)
             // log save of AI generated content
             val logPrefs = getSharedPreferences(ChangeLogStorage.PREFS_NAME, MODE_PRIVATE)

--- a/app/src/main/java/com/example/penmasnews/ui/ApprovalListActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/ApprovalListActivity.kt
@@ -5,7 +5,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.penmasnews.R
-import com.example.penmasnews.model.ApprovalStorage
+import com.example.penmasnews.model.EventStorage
 import com.example.penmasnews.ui.ApprovalListAdapter
 
 class ApprovalListActivity : AppCompatActivity() {
@@ -16,11 +16,11 @@ class ApprovalListActivity : AppCompatActivity() {
         val recyclerView = findViewById<RecyclerView>(R.id.recyclerViewApproval)
         recyclerView.layoutManager = LinearLayoutManager(this)
 
-        val prefs = getSharedPreferences(ApprovalStorage.PREFS_NAME, MODE_PRIVATE)
-        val events = ApprovalStorage.loadEvents(prefs)
+        val prefs = getSharedPreferences(EventStorage.PREFS_NAME, MODE_PRIVATE)
+        val events = EventStorage.loadEvents(prefs)
 
         val adapter = ApprovalListAdapter(events) {
-            ApprovalStorage.saveEvents(prefs, events)
+            EventStorage.saveEvents(prefs, events)
         }
         recyclerView.adapter = adapter
     }

--- a/app/src/main/java/com/example/penmasnews/ui/CMSIntegrationActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/CMSIntegrationActivity.kt
@@ -5,7 +5,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.penmasnews.R
-import com.example.penmasnews.model.ApprovalStorage
+import com.example.penmasnews.model.EventStorage
 
 class CMSIntegrationActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -15,8 +15,8 @@ class CMSIntegrationActivity : AppCompatActivity() {
         val recyclerView = findViewById<RecyclerView>(R.id.recyclerViewCms)
         recyclerView.layoutManager = LinearLayoutManager(this)
 
-        val prefs = getSharedPreferences(ApprovalStorage.PREFS_NAME, MODE_PRIVATE)
-        val events = ApprovalStorage.loadEvents(prefs).filter { it.status == "disetujui" }
+        val prefs = getSharedPreferences(EventStorage.PREFS_NAME, MODE_PRIVATE)
+        val events = EventStorage.loadEvents(prefs).filter { it.status == "disetujui" }
 
         val adapter = EditorialCalendarAdapter(events.toMutableList())
         recyclerView.adapter = adapter

--- a/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
@@ -41,13 +41,19 @@ class EditorialCalendarActivity : AppCompatActivity() {
         // load AI-assisted drafts stored from AIHelperActivity
         // events already include entries saved from AIHelperActivity
 
-        val adapter = EditorialCalendarAdapter(events,
-            onOpen = { event ->
+        val adapter = EditorialCalendarAdapter(
+            events,
+            onOpen = { _, index ->
                 val intent = android.content.Intent(this, CollaborativeEditorActivity::class.java)
+                intent.putExtra("index", index)
+                startActivity(intent)
+            },
+            onAiAssist = { event, index ->
+                val intent = android.content.Intent(this, AIHelperActivity::class.java)
+                intent.putExtra("index", index)
+                intent.putExtra("date", event.date)
                 intent.putExtra("title", event.topic)
-                intent.putExtra("content", event.content)
                 intent.putExtra("assignee", event.assignee)
-                intent.putExtra("status", event.status)
                 startActivity(intent)
             },
             onDelete = { _ ->

--- a/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarAdapter.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarAdapter.kt
@@ -12,7 +12,8 @@ import com.example.penmasnews.model.EditorialEvent
 
 class EditorialCalendarAdapter(
     private val items: MutableList<EditorialEvent>,
-    private val onOpen: ((EditorialEvent) -> Unit)? = null,
+    private val onOpen: ((EditorialEvent, Int) -> Unit)? = null,
+    private val onAiAssist: ((EditorialEvent, Int) -> Unit)? = null,
     private val onDelete: ((Int) -> Unit)? = null,
 ) : RecyclerView.Adapter<EditorialCalendarAdapter.ViewHolder>() {
 
@@ -46,11 +47,13 @@ class EditorialCalendarAdapter(
                 .setTitle(R.string.dialog_actions)
                 .setItems(arrayOf(
                     holder.itemView.context.getString(R.string.action_open),
+                    holder.itemView.context.getString(R.string.action_ai_assist),
                     holder.itemView.context.getString(R.string.action_delete)
                 )) { _, which ->
                     when (which) {
-                        0 -> onOpen?.invoke(item)
-                        1 -> {
+                        0 -> onOpen?.invoke(item, position)
+                        1 -> onAiAssist?.invoke(item, position)
+                        2 -> {
                             items.removeAt(position)
                             notifyItemRemoved(position)
                             onDelete?.invoke(position)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,6 +38,7 @@
     <string name="hint_add_next_column">Tambahkan kolom selanjutnya</string>
     <string name="action_generate">Generate Berita</string>
     <string name="action_open">Buka Editor</string>
+    <string name="action_ai_assist">Assistensi AI</string>
     <string name="action_paste">Tempel</string>
     <string name="action_clear">Bersihkan</string>
     <string name="dialog_actions">Tindakan</string>


### PR DESCRIPTION
## Summary
- add `Assistensi AI` to the calendar item menu
- open AI helper or editor with event index so features share the same event data
- save changes back to the single `EventStorage` store from AI helper, editor, approval and CMS integration

## Testing
- `gradlew` not found, unable to run tests

------
https://chatgpt.com/codex/tasks/task_e_687740a526b88327985d54b8f027c317