### PR TITLE
Fix dropdown heights

### DIFF
--- a/app/src/main/res/layout/activity_collaborative_editor.xml
+++ b/app/src/main/res/layout/activity_collaborative_editor.xml
@@ -55,7 +55,7 @@
             android:hint="@string/hint_assignee"
             android:layout_marginTop="8dp">
 
-            <AutoCompleteTextView
+            <com.google.android.material.textfield.MaterialAutoCompleteTextView
                 android:id="@+id/editAssignee"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
@@ -67,7 +67,7 @@
             android:hint="@string/hint_status"
             android:layout_marginTop="8dp">
 
-            <AutoCompleteTextView
+            <com.google.android.material.textfield.MaterialAutoCompleteTextView
                 android:id="@+id/editStatus"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />

--- a/app/src/main/res/layout/activity_editorial_calendar.xml
+++ b/app/src/main/res/layout/activity_editorial_calendar.xml
@@ -61,7 +61,7 @@
             android:hint="@string/hint_assignee"
             android:layout_marginTop="8dp">
 
-            <AutoCompleteTextView
+            <com.google.android.material.textfield.MaterialAutoCompleteTextView
                 android:id="@+id/editAssignee"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
@@ -73,7 +73,7 @@
             android:hint="@string/hint_status"
             android:layout_marginTop="8dp">
 
-            <AutoCompleteTextView
+            <com.google.android.material.textfield.MaterialAutoCompleteTextView
                 android:id="@+id/editStatus"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />


### PR DESCRIPTION
## Summary
- use MaterialAutoCompleteTextView widgets in Editorial Calendar
- use MaterialAutoCompleteTextView widgets in Collaborative Editor

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687750caf0508327bacd9ff893c62ef7