### PR TITLE
Integrate backend auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@
 OPENAI_API_KEY=your-openai-key
 BLOGGER_API_KEY=your-blogger-key
 BLOGGER_BLOG_ID=your-blog-id
+BACKEND_BASE_URL=http://localhost:3000/api

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,6 +11,7 @@ if (envFile.exists()) {
 def openAiKey = envProps.getProperty('OPENAI_API_KEY', '')
 def bloggerKey = envProps.getProperty('BLOGGER_API_KEY', '')
 def bloggerBlogId = envProps.getProperty('BLOGGER_BLOG_ID', '')
+def backendBaseUrl = envProps.getProperty('BACKEND_BASE_URL', '')
 
 android {
     namespace 'com.example.penmasnews'
@@ -25,6 +26,7 @@ android {
         buildConfigField 'String', 'OPENAI_API_KEY', '"' + openAiKey + '"'
         buildConfigField 'String', 'BLOGGER_API_KEY', '"' + bloggerKey + '"'
         buildConfigField 'String', 'BLOGGER_BLOG_ID', '"' + bloggerBlogId + '"'
+        buildConfigField 'String', 'BACKEND_BASE_URL', '"' + backendBaseUrl + '"'
     }
 
     buildTypes {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
         <activity android:name=".ui.CMSIntegrationActivity" />
         <activity android:name=".ui.AnalyticsDashboardActivity" />
         <activity android:name=".ui.ApprovalListActivity" />
+        <activity android:name=".ui.SignupActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/penmasnews/network/AuthService.kt
+++ b/app/src/main/java/com/example/penmasnews/network/AuthService.kt
@@ -1,0 +1,62 @@
+package com.example.penmasnews.network
+
+import com.example.penmasnews.BuildConfig
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONObject
+
+object AuthService {
+    private val client = OkHttpClient()
+    private val jsonType = "application/json; charset=utf-8".toMediaType()
+
+    data class Result(val success: Boolean, val token: String? = null, val message: String? = null, val role: String? = null)
+
+    fun login(username: String, password: String): Result {
+        val url = BuildConfig.BACKEND_BASE_URL.trimEnd('/') + "/auth/penmas-login"
+        val obj = JSONObject()
+        obj.put("username", username)
+        obj.put("password", password)
+        val request = Request.Builder()
+            .url(url)
+            .post(obj.toString().toRequestBody(jsonType))
+            .build()
+        client.newCall(request).execute().use { resp ->
+            val body = resp.body?.string()
+            if (!resp.isSuccessful || body == null) {
+                val msg = try { JSONObject(body ?: "{}").optString("message") } catch (_: Exception) { null }
+                return Result(false, message = msg)
+            }
+            val json = JSONObject(body)
+            return Result(
+                json.optBoolean("success"),
+                json.optString("token"),
+                json.optString("message", null),
+                json.optJSONObject("user")?.optString("role")
+                    ?: json.optJSONObject("client")?.optString("role")
+            )
+        }
+    }
+
+    fun signup(username: String, password: String, role: String): Result {
+        val url = BuildConfig.BACKEND_BASE_URL.trimEnd('/') + "/auth/penmas-register"
+        val obj = JSONObject()
+        obj.put("username", username)
+        obj.put("password", password)
+        obj.put("role", role)
+        val request = Request.Builder()
+            .url(url)
+            .post(obj.toString().toRequestBody(jsonType))
+            .build()
+        client.newCall(request).execute().use { resp ->
+            val body = resp.body?.string()
+            if (!resp.isSuccessful || body == null) {
+                val msg = try { JSONObject(body ?: "{}").optString("message") } catch (_: Exception) { null }
+                return Result(false, message = msg)
+            }
+            val json = JSONObject(body)
+            return Result(json.optBoolean("success"), json.optString("token"), json.optString("message"))
+        }
+    }
+}

--- a/app/src/main/java/com/example/penmasnews/ui/LoginActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/LoginActivity.kt
@@ -8,6 +8,7 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.example.penmasnews.MainActivity
 import com.example.penmasnews.R
+import com.example.penmasnews.network.AuthService
 
 class LoginActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -17,30 +18,36 @@ class LoginActivity : AppCompatActivity() {
         val editUsername = findViewById<TextInputEditText>(R.id.editUsername)
         val editPassword = findViewById<TextInputEditText>(R.id.editPassword)
         val buttonLogin = findViewById<Button>(R.id.buttonLogin)
+        val buttonSignup = findViewById<Button>(R.id.buttonSignup)
 
         buttonLogin.setOnClickListener {
             val username = editUsername.text.toString()
             val password = editPassword.text.toString()
+            Thread {
+                val result = AuthService.login(username, password)
+                runOnUiThread {
+                    if (result.success && result.token != null) {
+                        loginUser(username, result.role ?: "penulis", result.token)
+                    } else {
+                        Toast.makeText(this, result.message ?: getString(R.string.error_login), Toast.LENGTH_SHORT).show()
+                    }
+                }
+            }.start()
+        }
 
-            when {
-                username == "@papiqo" && password == "12345" -> {
-                    loginUser(username, "penulis")
-                }
-                username == "@penmas" && password == "12345" -> {
-                    loginUser(username, "editor")
-                }
-                else -> {
-                    Toast.makeText(this, R.string.error_login, Toast.LENGTH_SHORT).show()
-                }
-            }
+        buttonSignup.setOnClickListener {
+            startActivity(Intent(this, SignupActivity::class.java))
         }
     }
 
-    private fun loginUser(username: String, role: String) {
+    private fun loginUser(username: String, role: String, token: String) {
         val intent = Intent(this, MainActivity::class.java)
         intent.putExtra("actor", role)
         getSharedPreferences("user", MODE_PRIVATE)
-            .edit().putString("username", username).apply()
+            .edit()
+            .putString("username", username)
+            .putString("token", token)
+            .apply()
         startActivity(intent)
         finish()
     }

--- a/app/src/main/java/com/example/penmasnews/ui/SignupActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/SignupActivity.kt
@@ -1,0 +1,36 @@
+package com.example.penmasnews.ui
+
+import android.os.Bundle
+import android.widget.Button
+import com.google.android.material.textfield.TextInputEditText
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import com.example.penmasnews.R
+import com.example.penmasnews.network.AuthService
+
+class SignupActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_signup)
+
+        val editUsername = findViewById<TextInputEditText>(R.id.editSignupUsername)
+        val editPassword = findViewById<TextInputEditText>(R.id.editSignupPassword)
+        val buttonSignup = findViewById<Button>(R.id.buttonSignupSubmit)
+
+        buttonSignup.setOnClickListener {
+            val username = editUsername.text.toString()
+            val password = editPassword.text.toString()
+            Thread {
+                val result = AuthService.signup(username, password, "penulis")
+                runOnUiThread {
+                    if (result.success) {
+                        Toast.makeText(this, R.string.signup_success, Toast.LENGTH_SHORT).show()
+                        finish()
+                    } else {
+                        Toast.makeText(this, result.message ?: getString(R.string.error_signup), Toast.LENGTH_SHORT).show()
+                    }
+                }
+            }.start()
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_signup.xml
+++ b/app/src/main/res/layout/activity_signup.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -11,7 +10,7 @@
         android:layout_height="wrap_content">
 
         <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/editUsername"
+            android:id="@+id/editSignupUsername"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="@string/hint_username"
@@ -25,7 +24,7 @@
         app:endIconMode="password_toggle">
 
         <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/editPassword"
+            android:id="@+id/editSignupPassword"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="@string/hint_password"
@@ -34,16 +33,9 @@
     </com.google.android.material.textfield.TextInputLayout>
 
     <Button
-        android:id="@+id/buttonLogin"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/action_login"
-        android:layout_marginTop="16dp" />
-
-    <Button
-        android:id="@+id/buttonSignup"
+        android:id="@+id/buttonSignupSubmit"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/action_signup"
-        android:layout_marginTop="8dp" />
+        android:layout_marginTop="16dp" />
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,7 +55,10 @@
     <string name="hint_username">Username</string>
     <string name="hint_password">Password</string>
     <string name="action_login">Login</string>
+    <string name="action_signup">Sign Up</string>
     <string name="error_login">Login gagal</string>
+    <string name="error_signup">Pendaftaran gagal</string>
+    <string name="signup_success">Pendaftaran berhasil</string>
     <string name="hello_actor">Halo, %1$s</string>
 
     <string-array name="assignee_array">


### PR DESCRIPTION
## Summary
- add backend base URL to env and BuildConfig
- create `AuthService` for calling `/auth/penmas-login` and `/auth/penmas-register`
- wire up real login and new signup flow
- add signup activity and layout
- expose signup activity in Android manifest

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877d7fd45448327b33ab9acf2c31c12