### PR TITLE
Fix missing xmlns for signup layout

### DIFF
--- a/app/src/main/res/layout/activity_signup.xml
+++ b/app/src/main/res/layout/activity_signup.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"


### PR DESCRIPTION
## Summary
- add `xmlns:app` to the signup screen

## Testing
- `gradle test` *(fails: gradle wrapper not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877df2173d083278c188648ae989b01