### PR TITLE
Fix auth base URL handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,4 +2,5 @@
 OPENAI_API_KEY=your-openai-key
 BLOGGER_API_KEY=your-blogger-key
 BLOGGER_BLOG_ID=your-blog-id
-BACKEND_BASE_URL=http://localhost:3000/api
+# Base URL for the Cicero backend (without the trailing /api path)
+API_BASE_URL=http://localhost:3000

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ if (envFile.exists()) {
 def openAiKey = envProps.getProperty('OPENAI_API_KEY', '')
 def bloggerKey = envProps.getProperty('BLOGGER_API_KEY', '')
 def bloggerBlogId = envProps.getProperty('BLOGGER_BLOG_ID', '')
-def backendBaseUrl = envProps.getProperty('BACKEND_BASE_URL', '')
+def apiBaseUrl = envProps.getProperty('API_BASE_URL', '') ?: envProps.getProperty('BACKEND_BASE_URL', '')
 
 android {
     namespace 'com.example.penmasnews'
@@ -26,7 +26,9 @@ android {
         buildConfigField 'String', 'OPENAI_API_KEY', '"' + openAiKey + '"'
         buildConfigField 'String', 'BLOGGER_API_KEY', '"' + bloggerKey + '"'
         buildConfigField 'String', 'BLOGGER_BLOG_ID', '"' + bloggerBlogId + '"'
-        buildConfigField 'String', 'BACKEND_BASE_URL', '"' + backendBaseUrl + '"'
+        buildConfigField 'String', 'API_BASE_URL', '"' + apiBaseUrl + '"'
+        // keep old name for compatibility
+        buildConfigField 'String', 'BACKEND_BASE_URL', '"' + apiBaseUrl + '"'
     }
 
     buildTypes {

--- a/app/src/main/java/com/example/penmasnews/network/AuthService.kt
+++ b/app/src/main/java/com/example/penmasnews/network/AuthService.kt
@@ -20,7 +20,7 @@ object AuthService {
     )
 
     fun login(username: String, password: String): Result {
-        val url = BuildConfig.BACKEND_BASE_URL.trimEnd('/') + "/auth/penmas-login"
+        val url = BuildConfig.API_BASE_URL.trimEnd('/') + "/api/auth/penmas-login"
         val obj = JSONObject()
         obj.put("username", username)
         obj.put("password", password)
@@ -53,7 +53,7 @@ object AuthService {
     }
 
     fun signup(username: String, password: String, role: String): Result {
-        val url = BuildConfig.BACKEND_BASE_URL.trimEnd('/') + "/auth/penmas-register"
+        val url = BuildConfig.API_BASE_URL.trimEnd('/') + "/api/auth/penmas-register"
         val obj = JSONObject()
         obj.put("username", username)
         obj.put("password", password)


### PR DESCRIPTION
## Summary
- adapt env var and config names for API_BASE_URL
- support new auth endpoints under `/api`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68784785b2c08327b40df1de7b9cacf1