### PR TITLE
Add signup token support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ When the app starts you will be presented with a simple login screen. Use the
 credentials `@papiqo` with password `12345` to log in as the `penulis` actor or
 `@penmas` with the same password to log in as the `editor` actor.
 
+To register a new account, you must also provide a registration token obtained
+from the backend service. Without this token the server will return an error
+message like `token required`.
+
 ## Building the App
 
 This project uses Gradle. Because the Android SDK isn't bundled in this

--- a/app/src/main/java/com/example/penmasnews/network/AuthService.kt
+++ b/app/src/main/java/com/example/penmasnews/network/AuthService.kt
@@ -52,11 +52,12 @@ object AuthService {
         }
     }
 
-    fun signup(username: String, password: String, role: String): Result {
+    fun signup(username: String, password: String, token: String, role: String): Result {
         val url = BuildConfig.API_BASE_URL.trimEnd('/') + "/api/auth/penmas-register"
         val obj = JSONObject()
         obj.put("username", username)
         obj.put("password", password)
+        obj.put("token", token)
         obj.put("role", role)
         val request = Request.Builder()
             .url(url)

--- a/app/src/main/java/com/example/penmasnews/ui/SignupActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/SignupActivity.kt
@@ -18,13 +18,15 @@ class SignupActivity : AppCompatActivity() {
 
         val editUsername = findViewById<TextInputEditText>(R.id.editSignupUsername)
         val editPassword = findViewById<TextInputEditText>(R.id.editSignupPassword)
+        val editToken = findViewById<TextInputEditText>(R.id.editSignupToken)
         val buttonSignup = findViewById<Button>(R.id.buttonSignupSubmit)
 
         buttonSignup.setOnClickListener {
             val username = editUsername.text.toString()
             val password = editPassword.text.toString()
+            val token = editToken.text.toString()
             Thread {
-                val result = AuthService.signup(username, password, "penulis")
+                val result = AuthService.signup(username, password, token, "penulis")
                 runOnUiThread {
                     if (result.success) {
                         Toast.makeText(this, R.string.signup_success, Toast.LENGTH_SHORT).show()

--- a/app/src/main/res/layout/activity_signup.xml
+++ b/app/src/main/res/layout/activity_signup.xml
@@ -33,6 +33,19 @@
             android:singleLine="true" />
     </com.google.android.material.textfield.TextInputLayout>
 
+    <com.google.android.material.textfield.TextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/editSignupToken"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_signup_token"
+            android:singleLine="true" />
+    </com.google.android.material.textfield.TextInputLayout>
+
     <Button
         android:id="@+id/buttonSignupSubmit"
         android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,6 +54,7 @@
     </string-array>
     <string name="hint_username">Username</string>
     <string name="hint_password">Password</string>
+    <string name="hint_signup_token">Token</string>
     <string name="action_login">Login</string>
     <string name="action_signup">Sign Up</string>
     <string name="error_login">Login gagal</string>


### PR DESCRIPTION
## Summary
- support signup with a registration token
- show a token field in the signup screen
- update strings for the new hint
- document token requirement in README

## Testing
- `./gradlew assembleDebug` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68784dfe220083278206925bfbdfecfd