### PR TITLE
Update sign up for new backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,8 @@ When the app starts you will be presented with a simple login screen. Use the
 credentials `@papiqo` with password `12345` to log in as the `penulis` actor or
 `@penmas` with the same password to log in as the `editor` actor.
 
-To register a new account, you must also provide a registration token obtained
-from the backend service. Without this token the server will return an error
-message like `token required`.
+To create a new account simply enter a username, password and choose a role on
+the sign‑up form. No registration token is required.
 
 ## Building the App
 

--- a/app/src/main/java/com/example/penmasnews/network/AuthService.kt
+++ b/app/src/main/java/com/example/penmasnews/network/AuthService.kt
@@ -16,6 +16,7 @@ object AuthService {
         val token: String? = null,
         val message: String? = null,
         val role: String? = null,
+        val userId: String? = null,
         val raw: String? = null
     )
 
@@ -42,6 +43,8 @@ object AuthService {
                     json.optString("message", null),
                     json.optJSONObject("user")?.optString("role")
                         ?: json.optJSONObject("client")?.optString("role"),
+                    json.optJSONObject("user")?.optString("user_id")
+                        ?: json.optJSONObject("client")?.optString("client_id"),
                     raw = body
                 )
             }
@@ -52,12 +55,11 @@ object AuthService {
         }
     }
 
-    fun signup(username: String, password: String, token: String, role: String): Result {
+    fun signup(username: String, password: String, role: String): Result {
         val url = BuildConfig.API_BASE_URL.trimEnd('/') + "/api/auth/penmas-register"
         val obj = JSONObject()
         obj.put("username", username)
         obj.put("password", password)
-        obj.put("token", token)
         obj.put("role", role)
         val request = Request.Builder()
             .url(url)
@@ -73,8 +75,8 @@ object AuthService {
                 val json = JSONObject(body)
                 Result(
                     json.optBoolean("success"),
-                    json.optString("token"),
-                    json.optString("message"),
+                    message = json.optString("message", null),
+                    userId = json.optString("user_id", null),
                     raw = body
                 )
             }

--- a/app/src/main/java/com/example/penmasnews/ui/SignupActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/SignupActivity.kt
@@ -3,6 +3,7 @@ package com.example.penmasnews.ui
 import android.os.Bundle
 import android.widget.Button
 import com.google.android.material.textfield.TextInputEditText
+import android.widget.Spinner
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.example.penmasnews.R
@@ -18,15 +19,15 @@ class SignupActivity : AppCompatActivity() {
 
         val editUsername = findViewById<TextInputEditText>(R.id.editSignupUsername)
         val editPassword = findViewById<TextInputEditText>(R.id.editSignupPassword)
-        val editToken = findViewById<TextInputEditText>(R.id.editSignupToken)
+        val spinnerRole = findViewById<Spinner>(R.id.spinnerSignupRole)
         val buttonSignup = findViewById<Button>(R.id.buttonSignupSubmit)
 
         buttonSignup.setOnClickListener {
             val username = editUsername.text.toString()
             val password = editPassword.text.toString()
-            val token = editToken.text.toString()
+            val role = spinnerRole.selectedItem.toString()
             Thread {
-                val result = AuthService.signup(username, password, token, "penulis")
+                val result = AuthService.signup(username, password, role)
                 runOnUiThread {
                     if (result.success) {
                         Toast.makeText(this, R.string.signup_success, Toast.LENGTH_SHORT).show()

--- a/app/src/main/res/layout/activity_signup.xml
+++ b/app/src/main/res/layout/activity_signup.xml
@@ -33,18 +33,17 @@
             android:singleLine="true" />
     </com.google.android.material.textfield.TextInputLayout>
 
-    <com.google.android.material.textfield.TextInputLayout
+    <TextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp">
+        android:layout_marginTop="8dp"
+        android:text="@string/label_role" />
 
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/editSignupToken"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="@string/hint_signup_token"
-            android:singleLine="true" />
-    </com.google.android.material.textfield.TextInputLayout>
+    <Spinner
+        android:id="@+id/spinnerSignupRole"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:entries="@array/role_array" />
 
     <Button
         android:id="@+id/buttonSignupSubmit"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,13 +54,18 @@
     </string-array>
     <string name="hint_username">Username</string>
     <string name="hint_password">Password</string>
-    <string name="hint_signup_token">Token</string>
     <string name="action_login">Login</string>
     <string name="action_signup">Sign Up</string>
     <string name="error_login">Login gagal</string>
     <string name="error_signup">Pendaftaran gagal</string>
     <string name="signup_success">Pendaftaran berhasil</string>
     <string name="hello_actor">Halo, %1$s</string>
+
+    <string name="label_role">Role</string>
+    <string-array name="role_array">
+        <item>penulis</item>
+        <item>editor</item>
+    </string-array>
 
     <string-array name="assignee_array">
         <item>@papiqo</item>


### PR DESCRIPTION
## Summary
- remove registration token requirement from README
- allow selecting role in sign-up screen
- update sign-up layout and strings
- adjust network AuthService for new `/penmas-register` payload

## Testing
- `gradle build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687869a383b483278fd541dab6370f5f