### PR TITLE
Add splash screen with token validation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -56,4 +56,5 @@ dependencies {
     implementation 'com.google.android.material:material:1.10.0'
     implementation 'androidx.recyclerview:recyclerview:1.3.1'
     implementation 'com.squareup.okhttp3:okhttp:4.11.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,12 +7,13 @@
         android:allowBackup="true"
         android:label="@string/app_name"
         android:theme="@style/Theme.MaterialComponents.DayNight.DarkActionBar">
-        <activity android:name=".ui.LoginActivity" android:exported="true">
+        <activity android:name=".SplashActivity" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".ui.LoginActivity" android:exported="true" />
         <activity android:name=".MainActivity" android:exported="true" />
         <activity android:name=".ui.EditorialCalendarActivity" />
         <activity android:name=".ui.CollaborativeEditorActivity" />

--- a/app/src/main/java/com/example/penmasnews/SplashActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/SplashActivity.kt
@@ -1,0 +1,51 @@
+package com.example.penmasnews
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.example.penmasnews.network.AuthService
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class SplashActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        supportActionBar?.hide()
+        setContentView(R.layout.activity_splash)
+
+        val prefs = getSharedPreferences("auth", MODE_PRIVATE)
+        val token = prefs.getString("token", null)
+        val userId = prefs.getString("userId", null)
+        if (!token.isNullOrBlank() && !userId.isNullOrBlank()) {
+            validateToken(token, userId)
+        } else {
+            navigateToLogin()
+        }
+    }
+
+    private fun validateToken(token: String, userId: String) {
+        CoroutineScope(Dispatchers.IO).launch {
+            val ok = AuthService.validateToken(token, userId)
+            withContext(Dispatchers.Main) {
+                if (ok) {
+                    navigateToMain()
+                } else {
+                    navigateToLogin()
+                }
+            }
+        }
+    }
+
+    private fun navigateToLogin() {
+        startActivity(Intent(this, LoginActivity::class.java))
+        finish()
+    }
+
+    private fun navigateToMain() {
+        startActivity(Intent(this, MainActivity::class.java))
+        finish()
+    }
+}

--- a/app/src/main/java/com/example/penmasnews/network/AuthService.kt
+++ b/app/src/main/java/com/example/penmasnews/network/AuthService.kt
@@ -86,4 +86,15 @@ object AuthService {
             Result(false, message = e.message)
         }
     }
+
+    fun validateToken(token: String, userId: String): Boolean {
+        val url = BuildConfig.API_BASE_URL.trimEnd('/') + "/api/users/$userId"
+        val request = Request.Builder()
+            .url(url)
+            .header("Authorization", "Bearer $token")
+            .build()
+        return try {
+            client.newCall(request).execute().use { it.isSuccessful }
+        } catch (_: Exception) { false }
+    }
 }

--- a/app/src/main/java/com/example/penmasnews/ui/LoginActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/LoginActivity.kt
@@ -27,7 +27,12 @@ class LoginActivity : AppCompatActivity() {
                 val result = AuthService.login(username, password)
                 runOnUiThread {
                     if (result.success && result.token != null) {
-                        loginUser(username, result.role ?: "penulis", result.token)
+                        loginUser(
+                            username,
+                            result.role ?: "penulis",
+                            result.token,
+                            result.userId ?: ""
+                        )
                     } else {
                         Toast.makeText(this, result.message ?: getString(R.string.error_login), Toast.LENGTH_SHORT).show()
                     }
@@ -40,13 +45,15 @@ class LoginActivity : AppCompatActivity() {
         }
     }
 
-    private fun loginUser(username: String, role: String, token: String) {
+    private fun loginUser(username: String, role: String, token: String, userId: String) {
         val intent = Intent(this, MainActivity::class.java)
         intent.putExtra("actor", role)
-        getSharedPreferences("user", MODE_PRIVATE)
+        getSharedPreferences("auth", MODE_PRIVATE)
             .edit()
             .putString("username", username)
             .putString("token", token)
+            .putString("userId", userId)
+            .putString("role", role)
             .apply()
         startActivity(intent)
         finish()

--- a/app/src/main/res/layout/activity_splash.xml
+++ b/app/src/main/res/layout/activity_splash.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:orientation="vertical"
+    android:background="@android:drawable/screen_background_light">
+
+    <ImageView
+        android:layout_width="240dp"
+        android:layout_height="240dp"
+        android:src="@mipmap/ic_launcher_foreground"
+        android:contentDescription="@string/app_name" />
+
+    <ProgressBar
+        android:id="@+id/progress_splash"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp" />
+
+</LinearLayout>


### PR DESCRIPTION
## Summary
- include coroutine dependency
- launch SplashActivity for automatic login check
- store auth data in shared preferences on login
- add API helper to validate saved token

## Testing
- `./gradlew assembleDebug` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68786ed710a083278fcf35a6f3a56850