### PR TITLE
Fix missing launcher icon reference

### DIFF
--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#FF0000"
+        android:pathData="M0,0h108v108h-108z"/>
+</vector>

--- a/app/src/main/res/layout/activity_splash.xml
+++ b/app/src/main/res/layout/activity_splash.xml
@@ -9,7 +9,7 @@
     <ImageView
         android:layout_width="240dp"
         android:layout_height="240dp"
-        android:src="@mipmap/ic_launcher_foreground"
+        android:src="@drawable/ic_launcher_foreground"
         android:contentDescription="@string/app_name" />
 
     <ProgressBar


### PR DESCRIPTION
## Summary
- add missing `ic_launcher_foreground` drawable
- update splash screen to use the drawable

## Testing
- `gradle help` *(fails: Starting a Gradle Daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6878731b54388327b61143b739f2dff5