### PR TITLE
Fix missing LoginActivity import

### DIFF
--- a/app/src/main/java/com/example/penmasnews/SplashActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/SplashActivity.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.example.penmasnews.network.AuthService
+import com.example.penmasnews.ui.LoginActivity
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch


### PR DESCRIPTION
## Summary
- add missing import for LoginActivity in SplashActivity

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687875f0a1008327b281c9a763df3f37