### PR TITLE
Add backend event service

### DIFF
--- a/app/src/main/java/com/example/penmasnews/model/EventStorage.kt
+++ b/app/src/main/java/com/example/penmasnews/model/EventStorage.kt
@@ -1,47 +1,23 @@
 package com.example.penmasnews.model
 
-import android.content.SharedPreferences
-import org.json.JSONArray
-import org.json.JSONObject
+import android.content.Context
+import com.example.penmasnews.network.EventService
 
 /** Utility object for persisting editorial events in SharedPreferences. */
 object EventStorage {
     const val PREFS_NAME = "editorial_events"
 
-    fun loadEvents(prefs: SharedPreferences): MutableList<EditorialEvent> {
-        val json = prefs.getString("events", "[]") ?: "[]"
-        val array = JSONArray(json)
-        val list = mutableListOf<EditorialEvent>()
-        for (i in 0 until array.length()) {
-            val obj = array.getJSONObject(i)
-            list.add(
-                EditorialEvent(
-                    obj.optString("date"),
-                    obj.optString("topic"),
-                    obj.optString("assignee"),
-                    obj.optString("status"),
-                    obj.optString("content"),
-                    obj.optString("summary"),
-                    obj.optString("imagePath")
-                )
-            )
-        }
-        return list
+    fun loadEvents(context: Context): MutableList<EditorialEvent> {
+        val auth = context.getSharedPreferences("auth", Context.MODE_PRIVATE)
+        val token = auth.getString("token", null) ?: return mutableListOf()
+        return EventService.fetchEvents(token).toMutableList()
     }
 
-    fun saveEvents(prefs: SharedPreferences, events: List<EditorialEvent>) {
-        val array = JSONArray()
-        for (item in events) {
-            val obj = JSONObject()
-            obj.put("date", item.date)
-            obj.put("topic", item.topic)
-            obj.put("assignee", item.assignee)
-            obj.put("status", item.status)
-            obj.put("content", item.content)
-            obj.put("summary", item.summary)
-            obj.put("imagePath", item.imagePath)
-            array.put(obj)
+    fun saveEvents(context: Context, events: List<EditorialEvent>) {
+        val auth = context.getSharedPreferences("auth", Context.MODE_PRIVATE)
+        val token = auth.getString("token", null) ?: return
+        for (event in events) {
+            EventService.createEvent(token, event)
         }
-        prefs.edit().putString("events", array.toString()).apply()
     }
 }

--- a/app/src/main/java/com/example/penmasnews/network/EventService.kt
+++ b/app/src/main/java/com/example/penmasnews/network/EventService.kt
@@ -1,0 +1,70 @@
+package com.example.penmasnews.network
+
+import com.example.penmasnews.BuildConfig
+import com.example.penmasnews.model.EditorialEvent
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONArray
+import org.json.JSONObject
+
+object EventService {
+    private val client = OkHttpClient()
+    private val jsonType = "application/json; charset=utf-8".toMediaType()
+
+    fun fetchEvents(token: String): List<EditorialEvent> {
+        val url = BuildConfig.API_BASE_URL.trimEnd('/') + "/api/events"
+        val request = Request.Builder()
+            .url(url)
+            .header("Authorization", "Bearer $token")
+            .build()
+        return try {
+            client.newCall(request).execute().use { resp ->
+                val body = resp.body?.string()
+                if (!resp.isSuccessful || body == null) return emptyList()
+                val array = JSONArray(body)
+                val list = mutableListOf<EditorialEvent>()
+                for (i in 0 until array.length()) {
+                    val obj = array.getJSONObject(i)
+                    list.add(
+                        EditorialEvent(
+                            obj.optString("event_date"),
+                            obj.optString("topic"),
+                            obj.optString("assignee"),
+                            obj.optString("status"),
+                            obj.optString("content"),
+                            obj.optString("summary"),
+                            obj.optString("image_path")
+                        )
+                    )
+                }
+                list
+            }
+        } catch (_: Exception) {
+            emptyList()
+        }
+    }
+
+    fun createEvent(token: String, event: EditorialEvent): Boolean {
+        val url = BuildConfig.API_BASE_URL.trimEnd('/') + "/api/events"
+        val obj = JSONObject()
+        obj.put("event_date", event.date)
+        obj.put("topic", event.topic)
+        obj.put("assignee", event.assignee)
+        obj.put("status", event.status)
+        obj.put("content", event.content)
+        obj.put("summary", event.summary)
+        obj.put("image_path", event.imagePath)
+        val request = Request.Builder()
+            .url(url)
+            .post(obj.toString().toRequestBody(jsonType))
+            .header("Authorization", "Bearer $token")
+            .build()
+        return try {
+            client.newCall(request).execute().use { it.isSuccessful }
+        } catch (_: Exception) {
+            false
+        }
+    }
+}

--- a/app/src/main/java/com/example/penmasnews/ui/AIHelperActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/AIHelperActivity.kt
@@ -391,7 +391,7 @@ class AIHelperActivity : AppCompatActivity() {
         }
 
         saveButton.setOnClickListener {
-            val events = EventStorage.loadEvents(prefs)
+            val events = EventStorage.loadEvents(this)
             val event = EditorialEvent(
                 dateEdit.text.toString(),
                 titleOutput.text.toString(),
@@ -406,7 +406,7 @@ class AIHelperActivity : AppCompatActivity() {
             } else {
                 events.add(event)
             }
-            EventStorage.saveEvents(prefs, events)
+            EventStorage.saveEvents(this, events)
             // log save of AI generated content
             val logPrefs = getSharedPreferences(ChangeLogStorage.PREFS_NAME, MODE_PRIVATE)
             val logs = ChangeLogStorage.loadLogs(logPrefs)

--- a/app/src/main/java/com/example/penmasnews/ui/ApprovalListActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/ApprovalListActivity.kt
@@ -16,11 +16,10 @@ class ApprovalListActivity : AppCompatActivity() {
         val recyclerView = findViewById<RecyclerView>(R.id.recyclerViewApproval)
         recyclerView.layoutManager = LinearLayoutManager(this)
 
-        val prefs = getSharedPreferences(EventStorage.PREFS_NAME, MODE_PRIVATE)
-        val events = EventStorage.loadEvents(prefs)
+        val events = EventStorage.loadEvents(this)
 
         val adapter = ApprovalListAdapter(events) {
-            EventStorage.saveEvents(prefs, events)
+            EventStorage.saveEvents(this, events)
         }
         recyclerView.adapter = adapter
     }

--- a/app/src/main/java/com/example/penmasnews/ui/AssetManagerActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/AssetManagerActivity.kt
@@ -14,8 +14,7 @@ class AssetManagerActivity : AppCompatActivity() {
 
         val recyclerView = findViewById<RecyclerView>(R.id.recyclerViewAssets)
         recyclerView.layoutManager = GridLayoutManager(this, 3)
-        val prefs = getSharedPreferences(EventStorage.PREFS_NAME, MODE_PRIVATE)
-        val events = EventStorage.loadEvents(prefs)
+        val events = EventStorage.loadEvents(this)
         val images = events.mapNotNull { if (it.imagePath.isNotBlank()) it.imagePath else null }
         val adapter = AssetGridAdapter(images)
         recyclerView.adapter = adapter

--- a/app/src/main/java/com/example/penmasnews/ui/CMSIntegrationActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/CMSIntegrationActivity.kt
@@ -17,8 +17,7 @@ class CMSIntegrationActivity : AppCompatActivity() {
         val recyclerView = findViewById<RecyclerView>(R.id.recyclerViewCms)
         recyclerView.layoutManager = LinearLayoutManager(this)
 
-        val prefs = getSharedPreferences(EventStorage.PREFS_NAME, MODE_PRIVATE)
-        val events = EventStorage.loadEvents(prefs).filter { it.status == "disetujui" }
+        val events = EventStorage.loadEvents(this).filter { it.status == "disetujui" }
 
         val cms = CMSIntegration()
         val adapter = CmsIntegrationAdapter(events) { event ->

--- a/app/src/main/java/com/example/penmasnews/ui/CollaborativeEditorActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/CollaborativeEditorActivity.kt
@@ -53,7 +53,7 @@ class CollaborativeEditorActivity : AppCompatActivity() {
 
         val eventIndex = intent.getIntExtra("index", -1)
         val eventsPrefs = getSharedPreferences(EventStorage.PREFS_NAME, MODE_PRIVATE)
-        val events = EventStorage.loadEvents(eventsPrefs)
+        val events = EventStorage.loadEvents(this)
 
         val logPrefs = getSharedPreferences(ChangeLogStorage.PREFS_NAME, MODE_PRIVATE)
         val changeLogs = ChangeLogStorage.loadLogs(logPrefs)
@@ -93,7 +93,7 @@ class CollaborativeEditorActivity : AppCompatActivity() {
                     currentEvent?.summary ?: "",
                     imagePath ?: ""
                 )
-                EventStorage.saveEvents(eventsPrefs, events)
+                EventStorage.saveEvents(this, events)
             }
 
             val oldTitle = oldEvent?.topic ?: ""
@@ -125,7 +125,7 @@ class CollaborativeEditorActivity : AppCompatActivity() {
                 val event = events[eventIndex]
                 event.status = newStatus
                 events[eventIndex] = event
-                EventStorage.saveEvents(eventsPrefs, events)
+                EventStorage.saveEvents(this, events)
             }
             Snackbar.make(requestButton, R.string.status_changed_review, Snackbar.LENGTH_SHORT).show()
             startActivity(Intent(this, ApprovalListActivity::class.java))

--- a/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
@@ -42,7 +42,7 @@ class EditorialCalendarActivity : AppCompatActivity() {
 
         val prefs = getSharedPreferences(EventStorage.PREFS_NAME, MODE_PRIVATE)
 
-        val events = EventStorage.loadEvents(prefs).ifEmpty {
+        val events = EventStorage.loadEvents(this).ifEmpty {
             mutableListOf(
                 EditorialEvent("1 Jan", "Refleksi Awal Tahun", "Andi", "draft"),
                 EditorialEvent("5 Jan", "Tren Teknologi 2024", "Budi", "review"),
@@ -69,7 +69,7 @@ class EditorialCalendarActivity : AppCompatActivity() {
                 startActivity(intent)
             },
             onDelete = { _ ->
-                EventStorage.saveEvents(prefs, events)
+                EventStorage.saveEvents(this, events)
             }
         )
         recyclerView.adapter = adapter
@@ -88,7 +88,7 @@ class EditorialCalendarActivity : AppCompatActivity() {
                 return@setOnClickListener
             }
 
-            val eventsList = EventStorage.loadEvents(prefs)
+            val eventsList = EventStorage.loadEvents(this)
             val event = EditorialEvent(
                 dateEdit.text.toString(),
                 topicEdit.text.toString(),
@@ -96,7 +96,7 @@ class EditorialCalendarActivity : AppCompatActivity() {
                 status
             )
             eventsList.add(event)
-            EventStorage.saveEvents(prefs, eventsList)
+            EventStorage.saveEvents(this, eventsList)
             // log creation of new calendar event
             val logPrefs = getSharedPreferences(ChangeLogStorage.PREFS_NAME, MODE_PRIVATE)
             val logs = ChangeLogStorage.loadLogs(logPrefs)


### PR DESCRIPTION
## Summary
- migrate event storage to use backend API
- add `EventService` using OkHttp
- update activities to call `EventStorage` with context

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878a45a5f708327828fb8cbfdac8a4f