### PR TITLE
Remove dummy events and use text input for assignments

### DIFF
--- a/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
@@ -27,28 +27,18 @@ class EditorialCalendarActivity : AppCompatActivity() {
 
         val dateEdit = findViewById<EditText>(R.id.editDate)
         val topicEdit = findViewById<EditText>(R.id.editTopic)
-        val assigneeEdit = findViewById<AutoCompleteTextView>(R.id.editAssignee)
+        val assigneeEdit = findViewById<EditText>(R.id.editAssignee)
         val statusEdit = findViewById<AutoCompleteTextView>(R.id.editStatus)
         val addButton = findViewById<Button>(R.id.buttonAddEvent)
 
-        val assigneeList = resources.getStringArray(R.array.assignee_array)
         val statusList = resources.getStringArray(R.array.status_array)
-        assigneeEdit.setAdapter(
-            ArrayAdapter(this, android.R.layout.simple_dropdown_item_1line, assigneeList)
-        )
         statusEdit.setAdapter(
             ArrayAdapter(this, android.R.layout.simple_dropdown_item_1line, statusList)
         )
 
         val prefs = getSharedPreferences(EventStorage.PREFS_NAME, MODE_PRIVATE)
 
-        val events = EventStorage.loadEvents(this).ifEmpty {
-            mutableListOf(
-                EditorialEvent("1 Jan", "Refleksi Awal Tahun", "Andi", "draft"),
-                EditorialEvent("5 Jan", "Tren Teknologi 2024", "Budi", "review"),
-                EditorialEvent("10 Jan", "Wawancara Tokoh", "Citra", "publish")
-            )
-        }
+        val events = EventStorage.loadEvents(this)
 
         // load AI-assisted drafts stored from AIHelperActivity
         // events already include entries saved from AIHelperActivity
@@ -79,10 +69,6 @@ class EditorialCalendarActivity : AppCompatActivity() {
         addButton.setOnClickListener {
             val assignee = assigneeEdit.text.toString()
             val status = statusEdit.text.toString()
-            if (assignee !in assigneeList) {
-                Snackbar.make(addButton, R.string.error_invalid_assignee, Snackbar.LENGTH_SHORT).show()
-                return@setOnClickListener
-            }
             if (status !in statusList) {
                 Snackbar.make(addButton, R.string.error_invalid_status, Snackbar.LENGTH_SHORT).show()
                 return@setOnClickListener

--- a/app/src/main/res/layout/activity_editorial_calendar.xml
+++ b/app/src/main/res/layout/activity_editorial_calendar.xml
@@ -61,7 +61,7 @@
             android:hint="@string/hint_assignee"
             android:layout_marginTop="8dp">
 
-            <com.google.android.material.textfield.MaterialAutoCompleteTextView
+            <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/editAssignee"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />


### PR DESCRIPTION
## Summary
- simplify editorial calendar initialization by removing temporary event data
- change assignment field to normal text input

## Testing
- `gradle tasks --all`
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878af3f650083279c0c9d6335058b0b