### PR TITLE
Add server CRUD integration for editorial events

### DIFF
--- a/app/src/main/java/com/example/penmasnews/model/EditorialEvent.kt
+++ b/app/src/main/java/com/example/penmasnews/model/EditorialEvent.kt
@@ -10,5 +10,6 @@ data class EditorialEvent(
     var status: String,
     val content: String = "",
     val summary: String = "",
-    val imagePath: String = ""
+    val imagePath: String = "",
+    val id: Int = 0
 )

--- a/app/src/main/java/com/example/penmasnews/model/EventStorage.kt
+++ b/app/src/main/java/com/example/penmasnews/model/EventStorage.kt
@@ -13,11 +13,34 @@ object EventStorage {
         return EventService.fetchEvents(token).toMutableList()
     }
 
+    fun addEvent(context: Context, event: EditorialEvent): EditorialEvent? {
+        val auth = context.getSharedPreferences("auth", Context.MODE_PRIVATE)
+        val token = auth.getString("token", null) ?: return null
+        return EventService.createEvent(token, event)
+    }
+
+    fun updateEvent(context: Context, event: EditorialEvent): Boolean {
+        val auth = context.getSharedPreferences("auth", Context.MODE_PRIVATE)
+        val token = auth.getString("token", null) ?: return false
+        if (event.id == 0) return false
+        return EventService.updateEvent(token, event.id, event)
+    }
+
+    fun deleteEvent(context: Context, id: Int): Boolean {
+        val auth = context.getSharedPreferences("auth", Context.MODE_PRIVATE)
+        val token = auth.getString("token", null) ?: return false
+        return EventService.deleteEvent(token, id)
+    }
+
     fun saveEvents(context: Context, events: List<EditorialEvent>) {
         val auth = context.getSharedPreferences("auth", Context.MODE_PRIVATE)
         val token = auth.getString("token", null) ?: return
         for (event in events) {
-            EventService.createEvent(token, event)
+            if (event.id == 0) {
+                EventService.createEvent(token, event)
+            } else {
+                EventService.updateEvent(token, event.id, event)
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/penmasnews/ui/AIHelperActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/AIHelperActivity.kt
@@ -392,7 +392,7 @@ class AIHelperActivity : AppCompatActivity() {
 
         saveButton.setOnClickListener {
             val events = EventStorage.loadEvents(this)
-            val event = EditorialEvent(
+            var event = EditorialEvent(
                 dateEdit.text.toString(),
                 titleOutput.text.toString(),
                 "editor",
@@ -402,11 +402,17 @@ class AIHelperActivity : AppCompatActivity() {
                 selectedImagePath ?: ""
             )
             if (index >= 0 && index < events.size) {
-                events[index] = event
+                event = event.copy(id = events[index].id)
+                if (EventStorage.updateEvent(this, event)) {
+                    events[index] = event
+                }
             } else {
-                events.add(event)
+                val created = EventStorage.addEvent(this, event)
+                if (created != null) {
+                    event = created
+                    events.add(created)
+                }
             }
-            EventStorage.saveEvents(this, events)
             // log save of AI generated content
             val logPrefs = getSharedPreferences(ChangeLogStorage.PREFS_NAME, MODE_PRIVATE)
             val logs = ChangeLogStorage.loadLogs(logPrefs)

--- a/app/src/main/java/com/example/penmasnews/ui/ApprovalListActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/ApprovalListActivity.kt
@@ -18,8 +18,8 @@ class ApprovalListActivity : AppCompatActivity() {
 
         val events = EventStorage.loadEvents(this)
 
-        val adapter = ApprovalListAdapter(events) {
-            EventStorage.saveEvents(this, events)
+        val adapter = ApprovalListAdapter(events) { event ->
+            EventStorage.updateEvent(this, event)
         }
         recyclerView.adapter = adapter
     }

--- a/app/src/main/java/com/example/penmasnews/ui/ApprovalListAdapter.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/ApprovalListAdapter.kt
@@ -13,7 +13,7 @@ import com.example.penmasnews.model.ChangeLogStorage
 
 class ApprovalListAdapter(
     private val items: MutableList<EditorialEvent>,
-    private val onStatusChanged: (() -> Unit)? = null,
+    private val onStatusChanged: ((EditorialEvent) -> Unit)? = null,
 ) : RecyclerView.Adapter<ApprovalListAdapter.ViewHolder>() {
 
     class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
@@ -51,7 +51,7 @@ class ApprovalListAdapter(
                 )
             )
             ChangeLogStorage.saveLogs(logPrefs, logs)
-            onStatusChanged?.invoke()
+            onStatusChanged?.invoke(item)
         }
 
         holder.rejectButton.setOnClickListener {
@@ -71,7 +71,7 @@ class ApprovalListAdapter(
                 )
             )
             ChangeLogStorage.saveLogs(logPrefs, logs)
-            onStatusChanged?.invoke()
+            onStatusChanged?.invoke(item)
         }
     }
 

--- a/app/src/main/java/com/example/penmasnews/ui/CollaborativeEditorActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/CollaborativeEditorActivity.kt
@@ -84,16 +84,19 @@ class CollaborativeEditorActivity : AppCompatActivity() {
             val oldEvent = if (eventIndex in events.indices) events[eventIndex] else null
 
             if (eventIndex in events.indices) {
-                events[eventIndex] = EditorialEvent(
+                val updated = EditorialEvent(
                     currentEvent?.date ?: "",
                     titleEdit.text.toString(),
                     assignee,
                     statusEdit.text.toString(),
                     narrativeEdit.text.toString(),
                     currentEvent?.summary ?: "",
-                    imagePath ?: ""
+                    imagePath ?: "",
+                    events[eventIndex].id
                 )
-                EventStorage.saveEvents(this, events)
+                if (EventStorage.updateEvent(this, updated)) {
+                    events[eventIndex] = updated
+                }
             }
 
             val oldTitle = oldEvent?.topic ?: ""
@@ -123,9 +126,10 @@ class CollaborativeEditorActivity : AppCompatActivity() {
             statusEdit.setText(newStatus)
             if (eventIndex in events.indices) {
                 val event = events[eventIndex]
-                event.status = newStatus
-                events[eventIndex] = event
-                EventStorage.saveEvents(this, events)
+                val updated = event.copy(status = newStatus)
+                if (EventStorage.updateEvent(this, updated)) {
+                    events[eventIndex] = updated
+                }
             }
             Snackbar.make(requestButton, R.string.status_changed_review, Snackbar.LENGTH_SHORT).show()
             startActivity(Intent(this, ApprovalListActivity::class.java))

--- a/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
@@ -58,8 +58,10 @@ class EditorialCalendarActivity : AppCompatActivity() {
                 intent.putExtra("assignee", event.assignee)
                 startActivity(intent)
             },
-            onDelete = { _ ->
-                EventStorage.saveEvents(this, events)
+            onDelete = { item, _ ->
+                if (item.id != 0) {
+                    EventStorage.deleteEvent(this, item.id)
+                }
             }
         )
         recyclerView.adapter = adapter
@@ -74,15 +76,17 @@ class EditorialCalendarActivity : AppCompatActivity() {
                 return@setOnClickListener
             }
 
-            val eventsList = EventStorage.loadEvents(this)
             val event = EditorialEvent(
                 dateEdit.text.toString(),
                 topicEdit.text.toString(),
                 assignee,
                 status
             )
-            eventsList.add(event)
-            EventStorage.saveEvents(this, eventsList)
+            val created = EventStorage.addEvent(this, event)
+            if (created != null) {
+                events.add(created)
+                adapter.addItem(created)
+            }
             // log creation of new calendar event
             val logPrefs = getSharedPreferences(ChangeLogStorage.PREFS_NAME, MODE_PRIVATE)
             val logs = ChangeLogStorage.loadLogs(logPrefs)
@@ -98,7 +102,6 @@ class EditorialCalendarActivity : AppCompatActivity() {
                 )
             )
             ChangeLogStorage.saveLogs(logPrefs, logs)
-            adapter.addItem(event)
             dateEdit.text.clear()
             topicEdit.text.clear()
             assigneeEdit.text.clear()

--- a/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarAdapter.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarAdapter.kt
@@ -14,7 +14,7 @@ class EditorialCalendarAdapter(
     private val items: MutableList<EditorialEvent>,
     private val onOpen: ((EditorialEvent, Int) -> Unit)? = null,
     private val onAiAssist: ((EditorialEvent, Int) -> Unit)? = null,
-    private val onDelete: ((Int) -> Unit)? = null,
+    private val onDelete: ((EditorialEvent, Int) -> Unit)? = null,
 ) : RecyclerView.Adapter<EditorialCalendarAdapter.ViewHolder>() {
 
     class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
@@ -54,9 +54,9 @@ class EditorialCalendarAdapter(
                         0 -> onOpen?.invoke(item, position)
                         1 -> onAiAssist?.invoke(item, position)
                         2 -> {
-                            items.removeAt(position)
+                            val removed = items.removeAt(position)
                             notifyItemRemoved(position)
-                            onDelete?.invoke(position)
+                            onDelete?.invoke(removed, position)
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- extend `EventService` with read/create/update/delete helpers
- store event IDs in `EditorialEvent`
- update `EventStorage` to expose CRUD functions
- update editorial calendar UI to use remote CRUD calls
- hook up editor and approval flows to call update endpoints

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878b3c7af7c8327864e240ab8e6b9cc