### PR TITLE
Show logs in Asia/Jakarta timezone

### DIFF
--- a/app/src/main/java/com/example/penmasnews/model/ChangeLogEntry.kt
+++ b/app/src/main/java/com/example/penmasnews/model/ChangeLogEntry.kt
@@ -5,5 +5,6 @@ data class ChangeLogEntry(
     val user: String,
     val status: String,
     val changes: String,
+    /** Unix timestamp (seconds since epoch) */
     val timestamp: Long
 )

--- a/app/src/main/java/com/example/penmasnews/ui/AIHelperActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/AIHelperActivity.kt
@@ -424,7 +424,7 @@ class AIHelperActivity : AppCompatActivity() {
                     user,
                     event.status,
                     changesDesc,
-                    System.currentTimeMillis()
+                    System.currentTimeMillis() / 1000L
                 )
             )
             ChangeLogStorage.saveLogs(logPrefs, logs)

--- a/app/src/main/java/com/example/penmasnews/ui/ApprovalListAdapter.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/ApprovalListAdapter.kt
@@ -47,7 +47,7 @@ class ApprovalListAdapter(
                     user,
                     item.status,
                     "workflow approve",
-                    System.currentTimeMillis()
+                    System.currentTimeMillis() / 1000L
                 )
             )
             ChangeLogStorage.saveLogs(logPrefs, logs)
@@ -67,7 +67,7 @@ class ApprovalListAdapter(
                     user,
                     item.status,
                     "workflow reject",
-                    System.currentTimeMillis()
+                    System.currentTimeMillis() / 1000L
                 )
             )
             ChangeLogStorage.saveLogs(logPrefs, logs)

--- a/app/src/main/java/com/example/penmasnews/ui/CollaborativeEditorActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/CollaborativeEditorActivity.kt
@@ -115,7 +115,7 @@ class CollaborativeEditorActivity : AppCompatActivity() {
             val changesDesc = if (changed.isEmpty()) "no change" else changed.joinToString(", ")
             val userPrefs = getSharedPreferences("user", MODE_PRIVATE)
             val user = userPrefs.getString("username", "unknown") ?: "unknown"
-            val entry = ChangeLogEntry(user, statusEdit.text.toString(), changesDesc, System.currentTimeMillis())
+            val entry = ChangeLogEntry(user, statusEdit.text.toString(), changesDesc, System.currentTimeMillis() / 1000L)
             changeLogs.add(entry)
             ChangeLogStorage.saveLogs(logPrefs, changeLogs)
             displayLogs(changeLogs)
@@ -153,8 +153,10 @@ class CollaborativeEditorActivity : AppCompatActivity() {
 
     private fun displayLogs(logs: List<ChangeLogEntry>) {
         val df = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
+        df.timeZone = java.util.TimeZone.getTimeZone("Asia/Jakarta")
         logText.text = logs.joinToString("\n") {
-            "${df.format(Date(it.timestamp))} - ${it.user} - ${it.status} - ${it.changes}"
+            val date = Date(it.timestamp * 1000)
+            "${df.format(date)} - ${it.user} - ${it.status} - ${it.changes}"
         }
     }
 }

--- a/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
@@ -107,7 +107,7 @@ class EditorialCalendarActivity : AppCompatActivity() {
                             user,
                             event.status,
                             changesDesc,
-                            System.currentTimeMillis()
+                            System.currentTimeMillis() / 1000L
                         )
                     )
                     ChangeLogStorage.saveLogs(logPrefs, logs)


### PR DESCRIPTION
## Summary
- log timestamps in seconds rather than milliseconds
- display change log entries using Asia/Jakarta timezone

## Testing
- `gradle build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68790b9ba2f48327b4c39872b5d4aa01