### PR TITLE
Add metadata fields to editorial calendar

### DIFF
--- a/app/src/main/java/com/example/penmasnews/model/ApprovalStorage.kt
+++ b/app/src/main/java/com/example/penmasnews/model/ApprovalStorage.kt
@@ -22,7 +22,11 @@ object ApprovalStorage {
                     obj.optString("status"),
                     obj.optString("content"),
                     obj.optString("summary"),
-                    obj.optString("imagePath")
+                    obj.optString("imagePath"),
+                    obj.optInt("id"),
+                    obj.optString("createdAt"),
+                    obj.optString("updatedAt"),
+                    obj.optString("username")
                 )
             )
         }
@@ -40,6 +44,10 @@ object ApprovalStorage {
             obj.put("content", item.content)
             obj.put("summary", item.summary)
             obj.put("imagePath", item.imagePath)
+            obj.put("id", item.id)
+            obj.put("createdAt", item.createdAt)
+            obj.put("updatedAt", item.updatedAt)
+            obj.put("username", item.username)
             array.put(obj)
         }
         prefs.edit().putString("events", array.toString()).apply()

--- a/app/src/main/java/com/example/penmasnews/model/EditorialEvent.kt
+++ b/app/src/main/java/com/example/penmasnews/model/EditorialEvent.kt
@@ -11,5 +11,8 @@ data class EditorialEvent(
     val content: String = "",
     val summary: String = "",
     val imagePath: String = "",
-    val id: Int = 0
+    val id: Int = 0,
+    val createdAt: String = "",
+    val updatedAt: String = "",
+    val username: String = ""
 )

--- a/app/src/main/java/com/example/penmasnews/network/EventService.kt
+++ b/app/src/main/java/com/example/penmasnews/network/EventService.kt
@@ -37,7 +37,10 @@ object EventService {
                             obj.optString("content"),
                             obj.optString("summary"),
                             obj.optString("image_path"),
-                            obj.optInt("event_id")
+                            obj.optInt("event_id"),
+                            obj.optString("created_at"),
+                            obj.optString("updated_at"),
+                            obj.optString("username")
                         )
                     )
                 }
@@ -76,7 +79,10 @@ object EventService {
                     json.optString("content"),
                     json.optString("summary"),
                     json.optString("image_path"),
-                    json.optInt("event_id")
+                    json.optInt("event_id"),
+                    json.optString("created_at"),
+                    json.optString("updated_at"),
+                    json.optString("username")
                 )
             }
         } catch (_: Exception) {

--- a/app/src/main/java/com/example/penmasnews/ui/AIHelperActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/AIHelperActivity.kt
@@ -27,6 +27,7 @@ import org.json.JSONObject
 import androidx.appcompat.app.AppCompatActivity
 import com.example.penmasnews.R
 import java.util.Calendar
+import java.time.LocalDateTime
 
 class AIHelperActivity : AppCompatActivity() {
     private lateinit var imageView: ImageView
@@ -392,6 +393,8 @@ class AIHelperActivity : AppCompatActivity() {
 
         saveButton.setOnClickListener {
             val events = EventStorage.loadEvents(this)
+            val userPrefs = getSharedPreferences("user", MODE_PRIVATE)
+            val creator = userPrefs.getString("username", "") ?: ""
             var event = EditorialEvent(
                 dateEdit.text.toString(),
                 titleOutput.text.toString(),
@@ -399,10 +402,19 @@ class AIHelperActivity : AppCompatActivity() {
                 "dalam penulisan",
                 narrativeOutput.text.toString(),
                 summaryOutput.text.toString(),
-                selectedImagePath ?: ""
+                selectedImagePath ?: "",
+                0,
+                LocalDateTime.now().toString(),
+                LocalDateTime.now().toString(),
+                creator
             )
             if (index >= 0 && index < events.size) {
-                event = event.copy(id = events[index].id)
+                event = event.copy(
+                    id = events[index].id,
+                    createdAt = events[index].createdAt,
+                    updatedAt = LocalDateTime.now().toString(),
+                    username = events[index].username
+                )
                 if (EventStorage.updateEvent(this, event)) {
                     events[index] = event
                 }

--- a/app/src/main/java/com/example/penmasnews/ui/CmsIntegrationAdapter.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/CmsIntegrationAdapter.kt
@@ -22,6 +22,9 @@ class CmsIntegrationAdapter(
         val titleText: TextView = view.findViewById(R.id.textTitle)
         val notesText: TextView = view.findViewById(R.id.textNotes)
         val statusText: TextView = view.findViewById(R.id.textStatus)
+        val createdText: TextView = view.findViewById(R.id.textCreated)
+        val updatedText: TextView = view.findViewById(R.id.textUpdated)
+        val userText: TextView = view.findViewById(R.id.textUser)
         val actionButton: ImageButton = view.findViewById(R.id.buttonAction)
     }
 
@@ -37,6 +40,9 @@ class CmsIntegrationAdapter(
         holder.titleText.text = item.topic
         holder.notesText.text = item.assignee
         holder.statusText.text = item.status
+        holder.createdText.text = item.createdAt
+        holder.updatedText.text = item.updatedAt
+        holder.userText.text = item.username
         holder.itemView.setBackgroundResource(
             if (position % 2 == 0) R.color.zebra_even else R.color.zebra_odd
         )

--- a/app/src/main/java/com/example/penmasnews/ui/CollaborativeEditorActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/CollaborativeEditorActivity.kt
@@ -20,6 +20,7 @@ import com.example.penmasnews.R
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import java.time.LocalDateTime
 
 class CollaborativeEditorActivity : AppCompatActivity() {
     private lateinit var imageView: ImageView
@@ -92,7 +93,10 @@ class CollaborativeEditorActivity : AppCompatActivity() {
                     narrativeEdit.text.toString(),
                     currentEvent?.summary ?: "",
                     imagePath ?: "",
-                    events[eventIndex].id
+                    events[eventIndex].id,
+                    currentEvent?.createdAt ?: "",
+                    LocalDateTime.now().toString(),
+                    currentEvent?.username ?: ""
                 )
                 if (EventStorage.updateEvent(this, updated)) {
                     events[eventIndex] = updated

--- a/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
@@ -16,6 +16,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.example.penmasnews.R
 import com.example.penmasnews.model.EditorialEvent
 import java.util.Calendar
+import java.time.LocalDateTime
 
 class EditorialCalendarActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -83,11 +84,20 @@ class EditorialCalendarActivity : AppCompatActivity() {
                 return@setOnClickListener
             }
 
+            val userPrefs = getSharedPreferences("user", MODE_PRIVATE)
+            val creator = userPrefs.getString("username", "") ?: ""
             val event = EditorialEvent(
                 dateEdit.text.toString(),
                 topicEdit.text.toString(),
                 assignee,
-                status
+                status,
+                "",
+                "",
+                "",
+                0,
+                LocalDateTime.now().toString(),
+                LocalDateTime.now().toString(),
+                creator
             )
             Thread {
                 val created = EventStorage.addEvent(this, event)

--- a/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarAdapter.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarAdapter.kt
@@ -22,6 +22,9 @@ class EditorialCalendarAdapter(
         val titleText: TextView = view.findViewById(R.id.textTitle)
         val notesText: TextView = view.findViewById(R.id.textNotes)
         val statusText: TextView = view.findViewById(R.id.textStatus)
+        val createdText: TextView = view.findViewById(R.id.textCreated)
+        val updatedText: TextView = view.findViewById(R.id.textUpdated)
+        val userText: TextView = view.findViewById(R.id.textUser)
         val actionButton: ImageButton = view.findViewById(R.id.buttonAction)
     }
 
@@ -37,6 +40,9 @@ class EditorialCalendarAdapter(
         holder.titleText.text = item.topic
         holder.notesText.text = item.assignee
         holder.statusText.text = item.status
+        holder.createdText.text = item.createdAt
+        holder.updatedText.text = item.updatedAt
+        holder.userText.text = item.username
 
         holder.itemView.setBackgroundResource(
             if (position % 2 == 0) R.color.zebra_even else R.color.zebra_odd

--- a/app/src/main/res/layout/item_editorial_event.xml
+++ b/app/src/main/res/layout/item_editorial_event.xml
@@ -40,6 +40,27 @@
         android:layout_marginTop="2dp"
         android:textSize="14sp" />
 
+    <TextView
+        android:id="@+id/textCreated"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:textSize="12sp" />
+
+    <TextView
+        android:id="@+id/textUpdated"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:textSize="12sp" />
+
+    <TextView
+        android:id="@+id/textUser"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:textSize="12sp" />
+
     </LinearLayout>
 
     <ImageButton


### PR DESCRIPTION
## Summary
- extend `EditorialEvent` to include creator and timestamp fields
- parse new fields in `EventService`
- keep additional fields when storing approval requests
- pass user info when creating and updating events
- display creation info in editorial calendar and CMS integration lists

## Testing
- `gradle build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687913c8f20883279dbf2d65189728d5