### PR TITLE
Fix duplicate declaration in AIHelperActivity

### DIFF
--- a/app/src/main/java/com/example/penmasnews/ui/AIHelperActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/AIHelperActivity.kt
@@ -428,7 +428,6 @@ class AIHelperActivity : AppCompatActivity() {
             // log save of AI generated content
             val logPrefs = getSharedPreferences(ChangeLogStorage.PREFS_NAME, MODE_PRIVATE)
             val logs = ChangeLogStorage.loadLogs(logPrefs)
-            val userPrefs = getSharedPreferences("user", MODE_PRIVATE)
             val user = userPrefs.getString("username", "unknown") ?: "unknown"
             val changesDesc = listOf("ai_generated", "date", "title").joinToString(", ")
             logs.add(


### PR DESCRIPTION
## Summary
- remove duplicate `userPrefs` declaration in `AIHelperActivity`

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68791723d10c832796e7550fa0168f15