### PR TITLE
Fix duplicate SharedPreferences variable

### DIFF
--- a/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
@@ -109,7 +109,6 @@ class EditorialCalendarActivity : AppCompatActivity() {
                     // log creation of new calendar event
                     val logPrefs = getSharedPreferences(ChangeLogStorage.PREFS_NAME, MODE_PRIVATE)
                     val logs = ChangeLogStorage.loadLogs(logPrefs)
-                    val userPrefs = getSharedPreferences("user", MODE_PRIVATE)
                     val user = userPrefs.getString("username", "unknown") ?: "unknown"
                     val changesDesc = listOf("date", "topic", "assignee", "status").joinToString(", ")
                     logs.add(


### PR DESCRIPTION
## Summary
- remove nested `userPrefs` declaration in `EditorialCalendarActivity`

## Testing
- `gradlew assembleDebug` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687919d3a3bc8327bad91275f5a7b6f4