### PR TITLE
Fix editorial calendar duplication, username, and editor links

### DIFF
--- a/app/src/main/java/com/example/penmasnews/model/EditorialEvent.kt
+++ b/app/src/main/java/com/example/penmasnews/model/EditorialEvent.kt
@@ -3,6 +3,8 @@ package com.example.penmasnews.model
 /**
  * Data class representing a single item in the editorial calendar.
  */
+import java.io.Serializable
+
 data class EditorialEvent(
     val date: String,
     val topic: String,
@@ -15,4 +17,4 @@ data class EditorialEvent(
     val createdAt: String = "",
     val updatedAt: String = "",
     val username: String = ""
-)
+) : Serializable

--- a/app/src/main/java/com/example/penmasnews/ui/AIHelperActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/AIHelperActivity.kt
@@ -393,8 +393,8 @@ class AIHelperActivity : AppCompatActivity() {
 
         saveButton.setOnClickListener {
             val events = EventStorage.loadEvents(this)
-            val userPrefs = getSharedPreferences("user", MODE_PRIVATE)
-            val creator = userPrefs.getString("username", "") ?: ""
+            val authPrefs = getSharedPreferences("auth", MODE_PRIVATE)
+            val creator = authPrefs.getString("username", "") ?: ""
             var event = EditorialEvent(
                 dateEdit.text.toString(),
                 titleOutput.text.toString(),
@@ -428,7 +428,7 @@ class AIHelperActivity : AppCompatActivity() {
             // log save of AI generated content
             val logPrefs = getSharedPreferences(ChangeLogStorage.PREFS_NAME, MODE_PRIVATE)
             val logs = ChangeLogStorage.loadLogs(logPrefs)
-            val user = userPrefs.getString("username", "unknown") ?: "unknown"
+            val user = authPrefs.getString("username", "unknown") ?: "unknown"
             val changesDesc = listOf("ai_generated", "date", "title").joinToString(", ")
             logs.add(
                 ChangeLogEntry(

--- a/app/src/main/java/com/example/penmasnews/ui/ApprovalListAdapter.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/ApprovalListAdapter.kt
@@ -40,8 +40,8 @@ class ApprovalListAdapter(
             val context = holder.itemView.context
             val logPrefs = context.getSharedPreferences(ChangeLogStorage.PREFS_NAME, android.content.Context.MODE_PRIVATE)
             val logs = ChangeLogStorage.loadLogs(logPrefs)
-            val userPrefs = context.getSharedPreferences("user", android.content.Context.MODE_PRIVATE)
-            val user = userPrefs.getString("username", "unknown") ?: "unknown"
+            val authPrefs = context.getSharedPreferences("auth", android.content.Context.MODE_PRIVATE)
+            val user = authPrefs.getString("username", "unknown") ?: "unknown"
             logs.add(
                 ChangeLogEntry(
                     user,
@@ -60,8 +60,8 @@ class ApprovalListAdapter(
             val context = holder.itemView.context
             val logPrefs = context.getSharedPreferences(ChangeLogStorage.PREFS_NAME, android.content.Context.MODE_PRIVATE)
             val logs = ChangeLogStorage.loadLogs(logPrefs)
-            val userPrefs = context.getSharedPreferences("user", android.content.Context.MODE_PRIVATE)
-            val user = userPrefs.getString("username", "unknown") ?: "unknown"
+            val authPrefs = context.getSharedPreferences("auth", android.content.Context.MODE_PRIVATE)
+            val user = authPrefs.getString("username", "unknown") ?: "unknown"
             logs.add(
                 ChangeLogEntry(
                     user,

--- a/app/src/main/java/com/example/penmasnews/ui/CollaborativeEditorActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/CollaborativeEditorActivity.kt
@@ -52,15 +52,16 @@ class CollaborativeEditorActivity : AppCompatActivity() {
         statusEdit.isEnabled = false
         statusEdit.isFocusable = false
 
-        val eventIndex = intent.getIntExtra("index", -1)
+        val passedEvent = intent.getSerializableExtra("event") as? EditorialEvent
         val eventsPrefs = getSharedPreferences(EventStorage.PREFS_NAME, MODE_PRIVATE)
         val events = EventStorage.loadEvents(this)
+        val eventIndex = passedEvent?.let { evt -> events.indexOfFirst { it.id == evt.id } } ?: intent.getIntExtra("index", -1)
 
         val logPrefs = getSharedPreferences(ChangeLogStorage.PREFS_NAME, MODE_PRIVATE)
         val changeLogs = ChangeLogStorage.loadLogs(logPrefs)
         displayLogs(changeLogs)
 
-        val currentEvent = if (eventIndex in events.indices) events[eventIndex] else null
+        val currentEvent = if (eventIndex in events.indices) events[eventIndex] else passedEvent
         imagePath = currentEvent?.imagePath
         imagePath?.let { path ->
             if (path.isNotBlank()) imageView.setImageURI(android.net.Uri.fromFile(File(path)))
@@ -117,8 +118,8 @@ class CollaborativeEditorActivity : AppCompatActivity() {
             if (oldImage != (imagePath ?: "")) changed.add("image")
 
             val changesDesc = if (changed.isEmpty()) "no change" else changed.joinToString(", ")
-            val userPrefs = getSharedPreferences("user", MODE_PRIVATE)
-            val user = userPrefs.getString("username", "unknown") ?: "unknown"
+            val authPrefs = getSharedPreferences("auth", MODE_PRIVATE)
+            val user = authPrefs.getString("username", "unknown") ?: "unknown"
             val entry = ChangeLogEntry(user, statusEdit.text.toString(), changesDesc, System.currentTimeMillis() / 1000L)
             changeLogs.add(entry)
             ChangeLogStorage.saveLogs(logPrefs, changeLogs)


### PR DESCRIPTION
## Summary
- refresh calendar list from server after adding events
- pass full event object when opening collaborative editor
- display username from login info for logs and events
- mark `EditorialEvent` as Serializable

## Testing
- `gradle` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68791d1f0e70832781e913badfb2b5ea