### PR TITLE
Improve date handling and document timestamp use

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,4 @@ catatan, dan masukan teks, disediakan kolom untuk mengisi:
 
 - [Kalender Editorial & Ide](docs/editorial_calendar.md)
 - [Desain Halaman & Relasi Fitur](docs/ui_overview.md)
+- [Panduan Format Tanggal](docs/timestamp_usage.md)

--- a/app/src/main/java/com/example/penmasnews/ui/AIHelperActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/AIHelperActivity.kt
@@ -27,7 +27,7 @@ import org.json.JSONObject
 import androidx.appcompat.app.AppCompatActivity
 import com.example.penmasnews.R
 import java.util.Calendar
-import java.time.LocalDateTime
+import com.example.penmasnews.util.DateUtils
 
 class AIHelperActivity : AppCompatActivity() {
     private lateinit var imageView: ImageView
@@ -404,15 +404,15 @@ class AIHelperActivity : AppCompatActivity() {
                 summaryOutput.text.toString(),
                 selectedImagePath ?: "",
                 0,
-                LocalDateTime.now().toString(),
-                LocalDateTime.now().toString(),
+                DateUtils.now(),
+                DateUtils.now(),
                 creator
             )
             if (index >= 0 && index < events.size) {
                 event = event.copy(
                     id = events[index].id,
                     createdAt = events[index].createdAt,
-                    updatedAt = LocalDateTime.now().toString(),
+                    updatedAt = DateUtils.now(),
                     username = events[index].username
                 )
                 if (EventStorage.updateEvent(this, event)) {

--- a/app/src/main/java/com/example/penmasnews/ui/CollaborativeEditorActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/CollaborativeEditorActivity.kt
@@ -15,10 +15,7 @@ import com.example.penmasnews.model.ChangeLogDatabase
 import com.example.penmasnews.ui.ApprovalListActivity
 import androidx.appcompat.app.AppCompatActivity
 import com.example.penmasnews.R
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
-import java.time.LocalDateTime
+import com.example.penmasnews.util.DateUtils
 
 class CollaborativeEditorActivity : AppCompatActivity() {
     private lateinit var imageView: ImageView
@@ -79,7 +76,7 @@ class CollaborativeEditorActivity : AppCompatActivity() {
                     imagePath ?: "",
                     events[eventIndex].id,
                     currentEvent?.createdAt ?: "",
-                    LocalDateTime.now().toString(),
+                    DateUtils.now(),
                     currentEvent?.username ?: ""
                 )
                 if (EventStorage.updateEvent(this, updated)) {
@@ -139,11 +136,9 @@ class CollaborativeEditorActivity : AppCompatActivity() {
     }
 
     private fun displayLogs(logs: List<ChangeLogEntry>) {
-        val df = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
-        df.timeZone = java.util.TimeZone.getTimeZone("Asia/Jakarta")
         logText.text = logs.joinToString("\n") {
-            val date = Date(it.timestamp * 1000)
-            "${df.format(date)} - ${it.user} - ${it.status} - ${it.changes}"
+            val ts = DateUtils.formatTimestamp(it.timestamp)
+            "$ts - ${it.user} - ${it.status} - ${it.changes}"
         }
     }
 }

--- a/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
@@ -16,7 +16,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.example.penmasnews.R
 import com.example.penmasnews.model.EditorialEvent
 import java.util.Calendar
-import java.time.LocalDateTime
+import com.example.penmasnews.util.DateUtils
 
 class EditorialCalendarActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -96,8 +96,8 @@ class EditorialCalendarActivity : AppCompatActivity() {
                 "",
                 "",
                 0,
-                LocalDateTime.now().toString(),
-                LocalDateTime.now().toString(),
+                DateUtils.now(),
+                DateUtils.now(),
                 creator
             )
             Thread {

--- a/app/src/main/java/com/example/penmasnews/ui/LogListAdapter.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/LogListAdapter.kt
@@ -6,10 +6,7 @@ import android.view.ViewGroup
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import com.example.penmasnews.model.ChangeLogEntry
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
-import java.util.TimeZone
+import com.example.penmasnews.util.DateUtils
 
 class LogListAdapter(private val items: List<ChangeLogEntry>) :
     RecyclerView.Adapter<LogListAdapter.ViewHolder>() {
@@ -28,9 +25,7 @@ class LogListAdapter(private val items: List<ChangeLogEntry>) :
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val entry = items[position]
-        val df = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
-        df.timeZone = TimeZone.getTimeZone("Asia/Jakarta")
-        val text = "${df.format(Date(entry.timestamp * 1000))} - ${entry.user} - ${entry.status} - ${entry.changes}"
-        holder.text.text = text
+        val formatted = DateUtils.formatTimestamp(entry.timestamp)
+        holder.text.text = "$formatted - ${entry.user} - ${entry.status} - ${entry.changes}"
     }
 }

--- a/app/src/main/java/com/example/penmasnews/util/DateUtils.kt
+++ b/app/src/main/java/com/example/penmasnews/util/DateUtils.kt
@@ -1,0 +1,28 @@
+package com.example.penmasnews.util
+
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+/** Utility helpers for consistent date handling */
+object DateUtils {
+    const val DATE_FORMAT = "yyyy-MM-dd"
+    const val DATETIME_FORMAT = "yyyy-MM-dd HH:mm:ss"
+
+    private val dateTimeFormatter: DateTimeFormatter =
+        DateTimeFormatter.ofPattern(DATETIME_FORMAT)
+
+    /**
+     * Format the current time using [DATETIME_FORMAT].
+     */
+    fun now(): String = LocalDateTime.now().format(dateTimeFormatter)
+
+    /**
+     * Format a Unix timestamp (seconds) using [DATETIME_FORMAT] in Asia/Jakarta timezone.
+     */
+    fun formatTimestamp(epochSeconds: Long): String {
+        val zoned = Instant.ofEpochSecond(epochSeconds).atZone(ZoneId.of("Asia/Jakarta"))
+        return dateTimeFormatter.format(zoned)
+    }
+}

--- a/docs/timestamp_usage.md
+++ b/docs/timestamp_usage.md
@@ -1,0 +1,18 @@
+# Format Tanggal & Timestamp
+
+Aplikasi menggunakan dua format tanggal agar konsisten antara input dan output:
+
+* `yyyy-MM-dd` untuk kolom **event_date** pada backend dan isian tanggal di UI.
+* `yyyy-MM-dd HH:mm:ss` untuk informasi `createdAt`, `updatedAt`, dan pencatatan log.
+
+Utility `DateUtils` menyediakan helper `DateUtils.now()` untuk mendapatkan waktu
+saat ini dalam format tanggal dan waktu di atas, serta `DateUtils.formatTimestamp()`
+untuk menampilkan nilai Unix timestamp yang disimpan pada `ChangeLogEntry`.
+
+### Skenario Penggunaan Timestamp
+1. Pengguna menambahkan agenda baru di kalender editorial.
+2. Aplikasi memanggil `DateUtils.now()` untuk mengisi `createdAt` dan `updatedAt`.
+3. Setiap penyimpanan atau perubahan konten memanggil `System.currentTimeMillis() / 1000L`
+   untuk membuat timestamp detik pada `ChangeLogEntry`.
+4. Daftar log ditampilkan dengan `DateUtils.formatTimestamp()` sehingga seluruh
+tanggal tersaji konsisten dalam zona waktu Asia/Jakarta.


### PR DESCRIPTION
## Summary
- add `DateUtils` helper for consistent date formatting
- use `DateUtils` in AI helper, calendar, collaborative editor and log list
- document timestamp strategy

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6879d23ae8d48327bb048e8610443b3d