### PR TITLE
Update editorial screens for new backend format

### DIFF
--- a/app/src/main/java/com/example/penmasnews/network/LogService.kt
+++ b/app/src/main/java/com/example/penmasnews/network/LogService.kt
@@ -1,0 +1,62 @@
+package com.example.penmasnews.network
+
+import com.example.penmasnews.BuildConfig
+import com.example.penmasnews.model.ChangeLogEntry
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONArray
+import org.json.JSONObject
+import java.time.Instant
+
+object LogService {
+    private val client = OkHttpClient()
+    private val jsonType = "application/json; charset=utf-8".toMediaType()
+
+    fun fetchLogs(token: String, eventId: Int): List<ChangeLogEntry> {
+        val url = BuildConfig.API_BASE_URL.trimEnd('/') + "/api/events/$eventId/logs"
+        val request = Request.Builder()
+            .url(url)
+            .header("Authorization", "Bearer $token")
+            .build()
+        return try {
+            client.newCall(request).execute().use { resp ->
+                val body = resp.body?.string() ?: return emptyList()
+                if (!resp.isSuccessful) return emptyList()
+                val array = JSONObject(body).optJSONArray("data") ?: JSONArray()
+                val list = mutableListOf<ChangeLogEntry>()
+                for (i in 0 until array.length()) {
+                    val obj = array.getJSONObject(i)
+                    val epoch = runCatching { Instant.parse(obj.optString("logged_at")).epochSecond }.getOrDefault(0L)
+                    list.add(
+                        ChangeLogEntry(
+                            obj.optString("user_id"),
+                            obj.optString("status"),
+                            obj.optString("changes"),
+                            epoch
+                        )
+                    )
+                }
+                list
+            }
+        } catch (_: Exception) {
+            emptyList()
+        }
+    }
+
+    fun addLog(token: String, eventId: Int, log: ChangeLogEntry): Boolean {
+        val url = BuildConfig.API_BASE_URL.trimEnd('/') + "/api/events/$eventId/logs"
+        val obj = JSONObject()
+        obj.put("status", log.status)
+        obj.put("changes", log.changes)
+        val request = Request.Builder()
+            .url(url)
+            .post(obj.toString().toRequestBody(jsonType))
+            .header("Authorization", "Bearer $token")
+            .build()
+        return try {
+            client.newCall(request).execute().use { it.isSuccessful }
+        } catch (_: Exception) { false }
+    }
+}

--- a/app/src/main/java/com/example/penmasnews/util/DateUtils.kt
+++ b/app/src/main/java/com/example/penmasnews/util/DateUtils.kt
@@ -7,7 +7,7 @@ import java.time.format.DateTimeFormatter
 
 /** Utility helpers for consistent date handling */
 object DateUtils {
-    const val DATE_FORMAT = "yyyy-MM-dd"
+    const val DATE_FORMAT = "dd/MM/yyyy"
     const val DATETIME_FORMAT = "yyyy-MM-dd HH:mm:ss"
 
     private val dateTimeFormatter: DateTimeFormatter =

--- a/docs/timestamp_usage.md
+++ b/docs/timestamp_usage.md
@@ -2,7 +2,7 @@
 
 Aplikasi menggunakan dua format tanggal agar konsisten antara input dan output:
 
-* `yyyy-MM-dd` untuk kolom **event_date** pada backend dan isian tanggal di UI.
+* `dd/MM/yyyy` untuk kolom **event_date** pada backend dan isian tanggal di UI.
 * `yyyy-MM-dd HH:mm:ss` untuk informasi `createdAt`, `updatedAt`, dan pencatatan log.
 
 Utility `DateUtils` menyediakan helper `DateUtils.now()` untuk mendapatkan waktu


### PR DESCRIPTION
## Summary
- sync editorial calendar with backend log API
- sync collaborative editor with backend log API
- change date input to `dd/MM/yyyy`
- add `LogService` for remote log access
- document updated date format

## Testing
- `./gradlew test` *(fails: `No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6879e029ccec8327ae7e5abc748e4756