### PR TITLE
Update editorial calendar form

### DIFF
--- a/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
@@ -4,8 +4,6 @@ import android.app.DatePickerDialog
 import android.os.Bundle
 import android.widget.Button
 import android.widget.EditText
-import android.widget.AutoCompleteTextView
-import android.widget.ArrayAdapter
 import com.google.android.material.snackbar.Snackbar
 import com.example.penmasnews.model.EventStorage
 import com.example.penmasnews.model.ChangeLogEntry
@@ -29,13 +27,9 @@ class EditorialCalendarActivity : AppCompatActivity() {
         val dateEdit = findViewById<EditText>(R.id.editDate)
         val topicEdit = findViewById<EditText>(R.id.editTopic)
         val assigneeEdit = findViewById<EditText>(R.id.editAssignee)
-        val statusEdit = findViewById<AutoCompleteTextView>(R.id.editStatus)
+        val statusEdit = findViewById<EditText>(R.id.editStatus)
         val addButton = findViewById<Button>(R.id.buttonAddEvent)
 
-        val statusList = resources.getStringArray(R.array.status_array)
-        statusEdit.setAdapter(
-            ArrayAdapter(this, android.R.layout.simple_dropdown_item_1line, statusList)
-        )
 
         val prefs = getSharedPreferences(EventStorage.PREFS_NAME, MODE_PRIVATE)
 
@@ -80,10 +74,6 @@ class EditorialCalendarActivity : AppCompatActivity() {
         addButton.setOnClickListener {
             val assignee = assigneeEdit.text.toString()
             val status = statusEdit.text.toString()
-            if (status !in statusList) {
-                Snackbar.make(addButton, R.string.error_invalid_status, Snackbar.LENGTH_SHORT).show()
-                return@setOnClickListener
-            }
 
             val authPrefs = getSharedPreferences("auth", MODE_PRIVATE)
             val creator = authPrefs.getString("username", "") ?: ""

--- a/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarAdapter.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarAdapter.kt
@@ -36,12 +36,12 @@ class EditorialCalendarAdapter(
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val item = items[position]
-        holder.dateText.text = item.date
-        holder.titleText.text = item.topic
-        holder.notesText.text = item.assignee
-        holder.statusText.text = item.status
-        holder.createdText.text = item.createdAt
-        holder.updatedText.text = item.updatedAt
+        holder.dateText.text = "Penjadwalan : ${item.date}"
+        holder.titleText.text = "Topik : ${item.topic}"
+        holder.notesText.text = "Penugasan: ${item.assignee}"
+        holder.statusText.text = "Status : ${item.status}"
+        holder.createdText.text = "Created_at : ${item.createdAt}"
+        holder.updatedText.text = "Updated_at : ${item.updatedAt}"
         holder.userText.text = item.username
 
         holder.itemView.setBackgroundResource(

--- a/app/src/main/res/layout/activity_editorial_calendar.xml
+++ b/app/src/main/res/layout/activity_editorial_calendar.xml
@@ -73,7 +73,7 @@
             android:hint="@string/hint_status"
             android:layout_marginTop="8dp">
 
-            <com.google.android.material.textfield.MaterialAutoCompleteTextView
+            <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/editStatus"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />


### PR DESCRIPTION
## Summary
- make the status field a normal text input
- prefix fields in editorial calendar list with Indonesian labels

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6879e52723048327a5bc9a88172d57d8