### PR TITLE
Fix username display in logs

### DIFF
--- a/app/src/main/java/com/example/penmasnews/network/LogService.kt
+++ b/app/src/main/java/com/example/penmasnews/network/LogService.kt
@@ -31,7 +31,7 @@ object LogService {
                     val epoch = runCatching { Instant.parse(obj.optString("logged_at")).epochSecond }.getOrDefault(0L)
                     list.add(
                         ChangeLogEntry(
-                            obj.optString("user_id"),
+                            obj.optString("username"),
                             obj.optString("status"),
                             obj.optString("changes"),
                             epoch

--- a/app/src/main/java/com/example/penmasnews/ui/CollaborativeEditorActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/CollaborativeEditorActivity.kt
@@ -124,8 +124,8 @@ class CollaborativeEditorActivity : AppCompatActivity() {
             val changesDesc = if (changed.isEmpty()) "no change" else changed.joinToString(", ")
             val authPrefs = getSharedPreferences("auth", MODE_PRIVATE)
             val token = authPrefs.getString("token", null)
-            val userId = authPrefs.getString("userId", "0") ?: "0"
-            val entry = ChangeLogEntry(userId, statusEdit.text.toString(), changesDesc, System.currentTimeMillis() / 1000L)
+            val username = authPrefs.getString("username", "unknown") ?: "unknown"
+            val entry = ChangeLogEntry(username, statusEdit.text.toString(), changesDesc, System.currentTimeMillis() / 1000L)
             val evId = currentEvent?.id ?: 0
             if (token != null && evId != 0) {
                 Thread {

--- a/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
@@ -99,7 +99,7 @@ class EditorialCalendarActivity : AppCompatActivity() {
                     adapter.notifyDataSetChanged()
                     // log creation of new calendar event to backend
                     val token = authPrefs.getString("token", null)
-                    val userId = authPrefs.getString("userId", "0") ?: "0"
+                    val username = authPrefs.getString("username", "unknown") ?: "unknown"
                     val changesDesc = listOf("date", "topic", "assignee", "status").joinToString(", ")
                     val createdId = created?.id ?: 0
                     if (token != null && createdId != 0) {
@@ -107,7 +107,7 @@ class EditorialCalendarActivity : AppCompatActivity() {
                             LogService.addLog(
                                 token,
                                 createdId,
-                                ChangeLogEntry(userId, event.status, changesDesc, System.currentTimeMillis() / 1000L)
+                                ChangeLogEntry(username, event.status, changesDesc, System.currentTimeMillis() / 1000L)
                             )
                         }.start()
                     }


### PR DESCRIPTION
## Summary
- use `username` from API in `LogService` logs
- log username instead of user ID when saving events

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a0b66c0e883278eb42cbf697e4f3d