### PR TITLE
Align client with editorial_event backend

### DIFF
--- a/app/src/main/java/com/example/penmasnews/model/ApprovalStorage.kt
+++ b/app/src/main/java/com/example/penmasnews/model/ApprovalStorage.kt
@@ -25,8 +25,9 @@ object ApprovalStorage {
                     obj.optString("imagePath"),
                     obj.optInt("id"),
                     obj.optString("createdAt"),
-                    obj.optString("updatedAt"),
-                    obj.optString("username")
+                    obj.optString("lastUpdate"),
+                    obj.optString("username"),
+                    obj.optString("updatedBy")
                 )
             )
         }
@@ -46,8 +47,9 @@ object ApprovalStorage {
             obj.put("imagePath", item.imagePath)
             obj.put("id", item.id)
             obj.put("createdAt", item.createdAt)
-            obj.put("updatedAt", item.updatedAt)
+            obj.put("lastUpdate", item.lastUpdate)
             obj.put("username", item.username)
+            obj.put("updatedBy", item.updatedBy)
             array.put(obj)
         }
         prefs.edit().putString("events", array.toString()).apply()

--- a/app/src/main/java/com/example/penmasnews/model/EditorialEvent.kt
+++ b/app/src/main/java/com/example/penmasnews/model/EditorialEvent.kt
@@ -15,6 +15,7 @@ data class EditorialEvent(
     val imagePath: String = "",
     val id: Int = 0,
     val createdAt: String = "",
-    val updatedAt: String = "",
-    val username: String = ""
+    val lastUpdate: String = "",
+    val username: String = "",
+    val updatedBy: String = ""
 ) : Serializable

--- a/app/src/main/java/com/example/penmasnews/network/EventService.kt
+++ b/app/src/main/java/com/example/penmasnews/network/EventService.kt
@@ -28,6 +28,11 @@ object EventService {
                 val list = mutableListOf<EditorialEvent>()
                 for (i in 0 until array.length()) {
                     val obj = array.getJSONObject(i)
+                    val lastUpdate = if (obj.has("last_update")) {
+                        obj.optString("last_update")
+                    } else {
+                        obj.optString("last_updated")
+                    }
                     list.add(
                         EditorialEvent(
                             obj.optString("event_date"),
@@ -39,8 +44,9 @@ object EventService {
                             obj.optString("image_path"),
                             obj.optInt("event_id"),
                             obj.optString("created_at"),
-                            obj.optString("updated_at"),
-                            obj.optString("username")
+                            lastUpdate,
+                            obj.optString("username"),
+                            obj.optString("updated_by")
                         )
                     )
                 }
@@ -71,6 +77,11 @@ object EventService {
                 val body = resp.body?.string() ?: return null
                 if (!resp.isSuccessful) return null
                 val json = JSONObject(body).optJSONObject("data") ?: return null
+                val lastUpdate = if (json.has("last_update")) {
+                    json.optString("last_update")
+                } else {
+                    json.optString("last_updated")
+                }
                 EditorialEvent(
                     json.optString("event_date"),
                     json.optString("topic"),
@@ -81,8 +92,9 @@ object EventService {
                     json.optString("image_path"),
                     json.optInt("event_id"),
                     json.optString("created_at"),
-                    json.optString("updated_at"),
-                    json.optString("username")
+                    lastUpdate,
+                    json.optString("username"),
+                    json.optString("updated_by")
                 )
             }
         } catch (_: Exception) {

--- a/app/src/main/java/com/example/penmasnews/ui/AIHelperActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/AIHelperActivity.kt
@@ -406,14 +406,16 @@ class AIHelperActivity : AppCompatActivity() {
                 0,
                 DateUtils.now(),
                 DateUtils.now(),
+                creator,
                 creator
             )
             if (index >= 0 && index < events.size) {
                 event = event.copy(
                     id = events[index].id,
                     createdAt = events[index].createdAt,
-                    updatedAt = DateUtils.now(),
-                    username = events[index].username
+                    lastUpdate = DateUtils.now(),
+                    username = events[index].username,
+                    updatedBy = events[index].updatedBy
                 )
                 if (EventStorage.updateEvent(this, event)) {
                     events[index] = event

--- a/app/src/main/java/com/example/penmasnews/ui/CmsIntegrationAdapter.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/CmsIntegrationAdapter.kt
@@ -41,7 +41,7 @@ class CmsIntegrationAdapter(
         holder.notesText.text = item.assignee
         holder.statusText.text = item.status
         holder.createdText.text = item.createdAt
-        holder.updatedText.text = item.updatedAt
+        holder.updatedText.text = item.lastUpdate
         holder.userText.text = item.username
         holder.itemView.setBackgroundResource(
             if (position % 2 == 0) R.color.zebra_even else R.color.zebra_odd

--- a/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarAdapter.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarAdapter.kt
@@ -41,7 +41,7 @@ class EditorialCalendarAdapter(
         holder.notesText.text = "Penugasan: ${item.assignee}"
         holder.statusText.text = "Status : ${item.status}"
         holder.createdText.text = "Created_at : ${item.createdAt}"
-        holder.updatedText.text = "Updated_at : ${item.updatedAt}"
+        holder.updatedText.text = "Last_update : ${item.lastUpdate}"
         holder.userText.text = item.username
 
         holder.itemView.setBackgroundResource(

--- a/docs/timestamp_usage.md
+++ b/docs/timestamp_usage.md
@@ -3,7 +3,7 @@
 Aplikasi menggunakan dua format tanggal agar konsisten antara input dan output:
 
 * `dd/MM/yyyy` untuk kolom **event_date** pada backend dan isian tanggal di UI.
-* `yyyy-MM-dd HH:mm:ss` untuk informasi `createdAt`, `updatedAt`, dan pencatatan log.
+* `yyyy-MM-dd HH:mm:ss` untuk informasi `createdAt`, `lastUpdate`, dan pencatatan log.
 
 Utility `DateUtils` menyediakan helper `DateUtils.now()` untuk mendapatkan waktu
 saat ini dalam format tanggal dan waktu di atas, serta `DateUtils.formatTimestamp()`
@@ -11,7 +11,7 @@ untuk menampilkan nilai Unix timestamp yang disimpan pada `ChangeLogEntry`.
 
 ### Skenario Penggunaan Timestamp
 1. Pengguna menambahkan agenda baru di kalender editorial.
-2. Aplikasi memanggil `DateUtils.now()` untuk mengisi `createdAt` dan `updatedAt`.
+2. Aplikasi memanggil `DateUtils.now()` untuk mengisi `createdAt` dan `lastUpdate`.
 3. Setiap penyimpanan atau perubahan konten memanggil `System.currentTimeMillis() / 1000L`
    untuk membuat timestamp detik pada `ChangeLogEntry`.
 4. Daftar log ditampilkan dengan `DateUtils.formatTimestamp()` sehingga seluruh


### PR DESCRIPTION
## Summary
- track lastUpdate and updatedBy for editorial events
- parse `last_update`/`updated_by` from backend responses
- show lastUpdate in calendar & CMS lists
- document timestamp format update

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a191672cc8327b8412dc6fadc9760