### PR TITLE
Update editorial workflow

### DIFF
--- a/app/src/main/java/com/example/penmasnews/MainActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/MainActivity.kt
@@ -5,11 +5,9 @@ import android.os.Bundle
 import android.widget.Button
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
-import com.example.penmasnews.ui.AIHelperActivity
 import com.example.penmasnews.ui.AnalyticsDashboardActivity
 import com.example.penmasnews.ui.AssetManagerActivity
 import com.example.penmasnews.ui.CMSIntegrationActivity
-import com.example.penmasnews.ui.CollaborativeEditorActivity
 import com.example.penmasnews.ui.EditorialCalendarActivity
 import com.example.penmasnews.ui.ApprovalListActivity
 import com.example.penmasnews.ui.LogDataActivity
@@ -28,13 +26,6 @@ class MainActivity : AppCompatActivity() {
             startActivity(Intent(this, EditorialCalendarActivity::class.java))
         }
 
-        findViewById<Button>(R.id.buttonCollaborative).setOnClickListener {
-            startActivity(Intent(this, CollaborativeEditorActivity::class.java))
-        }
-
-        findViewById<Button>(R.id.buttonAIHelper).setOnClickListener {
-            startActivity(Intent(this, AIHelperActivity::class.java))
-        }
 
         findViewById<Button>(R.id.buttonAssetManager).setOnClickListener {
             startActivity(Intent(this, AssetManagerActivity::class.java))

--- a/app/src/main/java/com/example/penmasnews/ui/ApprovalListAdapter.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/ApprovalListAdapter.kt
@@ -35,7 +35,7 @@ class ApprovalListAdapter(
         holder.statusText.text = item.status
 
         holder.approveButton.setOnClickListener {
-            item.status = "disetujui"
+            item.status = "approved"
             notifyItemChanged(position)
             val context = holder.itemView.context
             val authPrefs = context.getSharedPreferences("auth", android.content.Context.MODE_PRIVATE)
@@ -53,7 +53,7 @@ class ApprovalListAdapter(
         }
 
         holder.rejectButton.setOnClickListener {
-            item.status = "revisi"
+            item.status = "rejected"
             notifyItemChanged(position)
             val context = holder.itemView.context
             val authPrefs = context.getSharedPreferences("auth", android.content.Context.MODE_PRIVATE)

--- a/app/src/main/java/com/example/penmasnews/ui/CMSIntegrationActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/CMSIntegrationActivity.kt
@@ -17,7 +17,7 @@ class CMSIntegrationActivity : AppCompatActivity() {
         val recyclerView = findViewById<RecyclerView>(R.id.recyclerViewCms)
         recyclerView.layoutManager = LinearLayoutManager(this)
 
-        val events = EventStorage.loadEvents(this).filter { it.status == "disetujui" }
+        val events = EventStorage.loadEvents(this).filter { it.status == "approved" }
 
         val cms = CMSIntegration()
         val adapter = CmsIntegrationAdapter(events) { event ->

--- a/app/src/main/java/com/example/penmasnews/ui/CollaborativeEditorActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/CollaborativeEditorActivity.kt
@@ -30,7 +30,6 @@ class CollaborativeEditorActivity : AppCompatActivity() {
         val titleEdit = findViewById<EditText>(R.id.editTitle)
         val narrativeEdit = findViewById<EditText>(R.id.editNarrative)
         val assigneeEdit = findViewById<EditText>(R.id.editAssignee)
-        val statusEdit = findViewById<EditText>(R.id.editStatus)
         imageView = findViewById(R.id.imageCollab)
         logText = findViewById(R.id.textLogs)
         val saveButton = findViewById<Button>(R.id.buttonSave)
@@ -79,7 +78,6 @@ class CollaborativeEditorActivity : AppCompatActivity() {
         titleEdit.setText(currentEvent?.topic ?: "")
         narrativeEdit.setText(currentEvent?.content ?: "")
         assigneeEdit.setText(currentEvent?.assignee ?: "")
-        statusEdit.setText(currentEvent?.status ?: "")
 
         saveButton.setOnClickListener {
             val assignee = assigneeEdit.text.toString()
@@ -91,7 +89,7 @@ class CollaborativeEditorActivity : AppCompatActivity() {
                     currentEvent?.date ?: "",
                     titleEdit.text.toString(),
                     assignee,
-                    statusEdit.text.toString(),
+                    "dalam penulisan",
                     narrativeEdit.text.toString(),
                     currentEvent?.summary ?: "",
                     imagePath ?: "",
@@ -111,21 +109,19 @@ class CollaborativeEditorActivity : AppCompatActivity() {
             val oldTitle = oldEvent?.topic ?: ""
             val oldContent = oldEvent?.content ?: ""
             val oldAssignee = oldEvent?.assignee ?: ""
-            val oldStatus = oldEvent?.status ?: ""
             val oldImage = oldEvent?.imagePath ?: ""
 
             val changed = mutableListOf<String>()
             if (oldTitle != titleEdit.text.toString()) changed.add("title")
             if (oldContent != narrativeEdit.text.toString()) changed.add("content")
             if (oldAssignee != assigneeEdit.text.toString()) changed.add("assignee")
-            if (oldStatus != statusEdit.text.toString()) changed.add("status")
             if (oldImage != (imagePath ?: "")) changed.add("image")
 
             val changesDesc = if (changed.isEmpty()) "no change" else changed.joinToString(", ")
             val authPrefs = getSharedPreferences("auth", MODE_PRIVATE)
             val token = authPrefs.getString("token", null)
             val username = authPrefs.getString("username", "unknown") ?: "unknown"
-            val entry = ChangeLogEntry(username, statusEdit.text.toString(), changesDesc, System.currentTimeMillis() / 1000L)
+            val entry = ChangeLogEntry(username, "dalam penulisan", changesDesc, System.currentTimeMillis() / 1000L)
             val evId = currentEvent?.id ?: 0
             if (token != null && evId != 0) {
                 Thread {
@@ -137,8 +133,7 @@ class CollaborativeEditorActivity : AppCompatActivity() {
         }
 
         requestButton.setOnClickListener {
-            val newStatus = "review"
-            statusEdit.setText(newStatus)
+            val newStatus = "meminta persetujuan"
             if (eventIndex in events.indices || (passedEvent?.id ?: 0) != 0) {
                 val baseEvent = if (eventIndex in events.indices) events[eventIndex] else passedEvent!!
                 val updated = baseEvent.copy(status = newStatus)

--- a/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
@@ -31,7 +31,6 @@ class EditorialCalendarActivity : AppCompatActivity() {
         val dateEdit = findViewById<EditText>(R.id.editDate)
         val topicEdit = findViewById<EditText>(R.id.editTopic)
         val assigneeEdit = findViewById<EditText>(R.id.editAssignee)
-        val statusEdit = findViewById<EditText>(R.id.editStatus)
         val addButton = findViewById<Button>(R.id.buttonAddEvent)
 
 
@@ -75,7 +74,7 @@ class EditorialCalendarActivity : AppCompatActivity() {
 
         addButton.setOnClickListener {
             val assignee = assigneeEdit.text.toString()
-            val status = statusEdit.text.toString()
+            val status = "ide"
 
             val authPrefs = getSharedPreferences("auth", MODE_PRIVATE)
             val creator = authPrefs.getString("username", "") ?: ""
@@ -116,7 +115,6 @@ class EditorialCalendarActivity : AppCompatActivity() {
                     dateEdit.text.clear()
                     topicEdit.text.clear()
                     assigneeEdit.text.clear()
-                    statusEdit.text.clear()
                 }
             }.start()
         }

--- a/app/src/main/res/layout/activity_collaborative_editor.xml
+++ b/app/src/main/res/layout/activity_collaborative_editor.xml
@@ -61,17 +61,6 @@
             android:layout_height="wrap_content" />
         </com.google.android.material.textfield.TextInputLayout>
 
-        <com.google.android.material.textfield.TextInputLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="@string/hint_status"
-            android:layout_marginTop="8dp">
-
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/editStatus"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
-        </com.google.android.material.textfield.TextInputLayout>
 
         <TextView
             android:id="@+id/textLogHeader"

--- a/app/src/main/res/layout/activity_editorial_calendar.xml
+++ b/app/src/main/res/layout/activity_editorial_calendar.xml
@@ -67,17 +67,6 @@
                 android:layout_height="wrap_content" />
         </com.google.android.material.textfield.TextInputLayout>
 
-        <com.google.android.material.textfield.TextInputLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="@string/hint_status"
-            android:layout_marginTop="8dp">
-
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/editStatus"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
-        </com.google.android.material.textfield.TextInputLayout>
 
         <Button
             android:id="@+id/buttonAddEvent"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -30,21 +30,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/feature_editorial_calendar" />
-
-        <Button
-            android:id="@+id/buttonCollaborative"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/feature_collaborative_writing"
-            android:layout_marginTop="8dp" />
-
-        <Button
-            android:id="@+id/buttonAIHelper"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/feature_ai_assistance"
-            android:layout_marginTop="8dp" />
-
         <Button
             android:id="@+id/buttonAssetManager"
             android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,7 +8,7 @@
     <string name="feature_cms_integration">Integrasi CMS &amp; Sosial Media</string>
     <string name="feature_analytics">Analitik &amp; Umpan Balik</string>
     <string name="feature_log_data">Log Data</string>
-    <string name="desc_home">Tampilan awal berisi daftar tombol menuju setiap fitur.\nMenjadi hub utama untuk berpindah ke Kalender Editorial, Penulisan Kolaboratif, Asistensi AI, Manajemen Aset, Workflow Approval, Integrasi CMS, dan Analitik.</string>
+    <string name="desc_home">Tampilan awal berisi daftar tombol menuju setiap fitur.\nMenjadi hub utama untuk berpindah ke Kalender Editorial, Manajemen Aset, Workflow Approval, Integrasi CMS, dan Analitik.</string>
     <string name="desc_editorial_calendar">Menampilkan daftar atau kalender berisi ide topik, penjadwalan, penugasan, dan status.\nDari halaman ini pengguna dapat membuka dokumen di Penulisan Kolaboratif atau menetapkan proses ke Workflow Approval.</string>
     <string name="desc_collaborative_editor">Editor teks bersama dengan dukungan komentar, histori, dan track changes.\nDapat diakses dari Kalender Editorial maupun langsung dari Beranda.\nSetelah selesai, draf dikirim ke Workflow Approval.</string>
     <string name="desc_ai_helper">Fitur opsional yang membantu peringkasan, saran judul, dan pengecekan bahasa.\nDipanggil dari dalam Penulisan Kolaboratif atau dari Beranda untuk kebutuhan terpisah.</string>
@@ -83,5 +83,5 @@
     </string-array>
     <string name="error_invalid_assignee">Penugasan harus dipilih dari daftar</string>
     <string name="error_invalid_status">Status harus dipilih dari daftar</string>
-    <string name="status_changed_review">Status diubah menjadi review</string>
+    <string name="status_changed_review">Status diubah menjadi meminta persetujuan</string>
 </resources>


### PR DESCRIPTION
## Summary
- restrict Collaborative Writer and AI Helper to only launch from the calendar
- default new calendar entries to `ide`
- remove status input from collaborative editor and set status to `dalam penulisan`
- change approval workflow status values
- update strings and menu

## Testing
- `gradle build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a1fd17b28832782645183cd3b3df6