### PR TITLE
Fix null String mismatch

### DIFF
--- a/app/src/main/java/com/example/penmasnews/ui/CollaborativeEditorActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/CollaborativeEditorActivity.kt
@@ -150,7 +150,7 @@ class CollaborativeEditorActivity : AppCompatActivity() {
                 val updated = baseEvent.copy(
                     status = newStatus,
                     lastUpdate = DateUtils.now(),
-                    updatedBy = getSharedPreferences("auth", MODE_PRIVATE).getString("username", baseEvent.updatedBy)
+                    updatedBy = getSharedPreferences("auth", MODE_PRIVATE).getString("username", baseEvent.updatedBy) ?: baseEvent.updatedBy
                 )
                 Thread {
                     val success = EventStorage.updateEvent(this, updated)


### PR DESCRIPTION
## Summary
- ensure username passed to `copy()` is always non-null

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a27f0fc9883279551a66c637c1ff0