### PR TITLE
Improve night mode list readability

### DIFF
--- a/app/src/main/res/drawable-night/list_border.xml
+++ b/app/src/main/res/drawable-night/list_border.xml
@@ -1,0 +1,5 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="#424242"/>
+    <stroke android:width="1dp" android:color="#616161"/>
+    <corners android:radius="8dp"/>
+</shape>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,4 @@
+<resources>
+    <color name="zebra_even">#424242</color>
+    <color name="zebra_odd">#303030</color>
+</resources>


### PR DESCRIPTION
## Summary
- support dark mode zebra colors for list rows
- add dark version of `list_border` drawable

## Testing
- `gradle help` *(fails: Starting a Gradle Daemon)*

------
https://chatgpt.com/codex/tasks/task_e_687a41cfd1d8832786dd8eaeec9e1f4f