### PR TITLE
Improve editorial list row layout

### DIFF
--- a/app/src/main/java/com/example/penmasnews/ui/CmsIntegrationAdapter.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/CmsIntegrationAdapter.kt
@@ -23,9 +23,10 @@ class CmsIntegrationAdapter(
         val titleText: TextView = view.findViewById(R.id.textTitle)
         val notesText: TextView = view.findViewById(R.id.textNotes)
         val statusText: TextView = view.findViewById(R.id.textStatus)
+        val createdByText: TextView = view.findViewById(R.id.textUser)
         val createdText: TextView = view.findViewById(R.id.textCreated)
+        val updatedByText: TextView = view.findViewById(R.id.textUpdatedBy)
         val updatedText: TextView = view.findViewById(R.id.textUpdated)
-        val userText: TextView = view.findViewById(R.id.textUser)
         val actionButton: ImageButton = view.findViewById(R.id.buttonAction)
     }
 
@@ -37,13 +38,14 @@ class CmsIntegrationAdapter(
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val item = items[position]
-        holder.dateText.text = item.date
+        holder.dateText.text = DateUtils.formatDayDate(item.date)
         holder.titleText.text = item.topic
         holder.notesText.text = item.assignee
         holder.statusText.text = item.status
+        holder.createdByText.text = item.username
         holder.createdText.text = DateUtils.formatDateTime(item.createdAt)
+        holder.updatedByText.text = item.updatedBy
         holder.updatedText.text = DateUtils.formatDateTime(item.lastUpdate)
-        holder.userText.text = item.username
         holder.itemView.setBackgroundResource(
             if (position % 2 == 0) R.color.zebra_even else R.color.zebra_odd
         )

--- a/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarAdapter.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarAdapter.kt
@@ -23,9 +23,10 @@ class EditorialCalendarAdapter(
         val titleText: TextView = view.findViewById(R.id.textTitle)
         val notesText: TextView = view.findViewById(R.id.textNotes)
         val statusText: TextView = view.findViewById(R.id.textStatus)
+        val createdByText: TextView = view.findViewById(R.id.textUser)
         val createdText: TextView = view.findViewById(R.id.textCreated)
+        val updatedByText: TextView = view.findViewById(R.id.textUpdatedBy)
         val updatedText: TextView = view.findViewById(R.id.textUpdated)
-        val userText: TextView = view.findViewById(R.id.textUser)
         val actionButton: ImageButton = view.findViewById(R.id.buttonAction)
     }
 
@@ -37,13 +38,14 @@ class EditorialCalendarAdapter(
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val item = items[position]
-        holder.dateText.text = "Penjadwalan : ${item.date}"
+        holder.dateText.text = "Penjadwalan : ${DateUtils.formatDayDate(item.date)}"
         holder.titleText.text = "Topik : ${item.topic}"
-        holder.notesText.text = "Penugasan: ${item.assignee}"
-        holder.statusText.text = "Status : ${item.status}"
-        holder.createdText.text = "Created_at : ${DateUtils.formatDateTime(item.createdAt)}"
-        holder.updatedText.text = "Last_update : ${DateUtils.formatDateTime(item.lastUpdate)}"
-        holder.userText.text = item.username
+        holder.notesText.text = "Penugasan : ${item.assignee}"
+        holder.statusText.text = "Status: ${item.status}"
+        holder.createdByText.text = "Created by : ${item.username}"
+        holder.createdText.text = "Created at : ${DateUtils.formatDateTime(item.createdAt)}"
+        holder.updatedByText.text = "Updated by : ${item.updatedBy}"
+        holder.updatedText.text = "Last Updated : ${DateUtils.formatDateTime(item.lastUpdate)}"
 
         holder.itemView.setBackgroundResource(
             if (position % 2 == 0) R.color.zebra_even else R.color.zebra_odd

--- a/app/src/main/java/com/example/penmasnews/util/DateUtils.kt
+++ b/app/src/main/java/com/example/penmasnews/util/DateUtils.kt
@@ -1,9 +1,12 @@
 package com.example.penmasnews.util
 
 import java.time.Instant
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import java.time.format.TextStyle
+import java.util.Locale
 
 /** Utility helpers for consistent date handling */
 object DateUtils {
@@ -38,6 +41,19 @@ object DateUtils {
             } else {
                 LocalDateTime.parse(raw, dateTimeFormatter).format(dateTimeFormatter)
             }
+        } catch (_: Exception) {
+            raw
+        }
+    }
+
+    /**
+     * Convert a date in [DATE_FORMAT] to "EEEE, dd/MM/yyyy" localized in Indonesian.
+     */
+    fun formatDayDate(raw: String): String {
+        return try {
+            val localDate = LocalDate.parse(raw, DateTimeFormatter.ofPattern(DATE_FORMAT))
+            val day = localDate.dayOfWeek.getDisplayName(TextStyle.FULL, Locale("id", "ID"))
+            "$day, ${localDate.format(DateTimeFormatter.ofPattern(DATE_FORMAT))}"
         } catch (_: Exception) {
             raw
         }

--- a/app/src/main/res/layout/item_editorial_event.xml
+++ b/app/src/main/res/layout/item_editorial_event.xml
@@ -41,6 +41,13 @@
         android:textSize="14sp" />
 
     <TextView
+        android:id="@+id/textUser"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:textSize="12sp" />
+
+    <TextView
         android:id="@+id/textCreated"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -48,14 +55,14 @@
         android:textSize="12sp" />
 
     <TextView
-        android:id="@+id/textUpdated"
+        android:id="@+id/textUpdatedBy"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="2dp"
         android:textSize="12sp" />
 
     <TextView
-        android:id="@+id/textUser"
+        android:id="@+id/textUpdated"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="2dp"


### PR DESCRIPTION
## Summary
- show creator, creation date, updater and last update in editorial list
- calculate day name for calendar entries
- extend layout to display new fields in CMS integration

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a435ebd788327a1e86b94156722de