### PR TITLE
Add analytics design doc and placeholder UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,4 @@ catatan, dan masukan teks, disediakan kolom untuk mengisi:
 - [Kalender Editorial & Ide](docs/editorial_calendar.md)
 - [Desain Halaman & Relasi Fitur](docs/ui_overview.md)
 - [Panduan Format Tanggal](docs/timestamp_usage.md)
+- [Halaman Analitik](docs/analytics_dashboard.md)

--- a/app/src/main/java/com/example/penmasnews/ui/AnalyticsDashboardActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/AnalyticsDashboardActivity.kt
@@ -4,8 +4,12 @@ import android.app.DatePickerDialog
 import android.os.Bundle
 import android.widget.Button
 import android.widget.EditText
+import android.widget.TextView
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import androidx.appcompat.app.AppCompatActivity
 import com.example.penmasnews.R
+import com.example.penmasnews.ui.TrendingTopicAdapter
 import java.util.Calendar
 
 class AnalyticsDashboardActivity : AppCompatActivity() {
@@ -16,6 +20,10 @@ class AnalyticsDashboardActivity : AppCompatActivity() {
         val dateEdit = findViewById<EditText>(R.id.editDate)
         val notesEdit = findViewById<EditText>(R.id.editNotes)
         val saveButton = findViewById<Button>(R.id.buttonSave)
+        val viewsText = findViewById<TextView>(R.id.textViews)
+        val visitorsText = findViewById<TextView>(R.id.textVisitors)
+        val bounceText = findViewById<TextView>(R.id.textBounce)
+        val trendingList = findViewById<RecyclerView>(R.id.recyclerViewTrending)
 
         val prefs = getSharedPreferences(javaClass.simpleName, MODE_PRIVATE)
 
@@ -32,6 +40,22 @@ class AnalyticsDashboardActivity : AppCompatActivity() {
                 .putString("notes", notesEdit.text.toString())
                 .apply()
         }
+
+        // Placeholder angka metrik, seharusnya diambil dari layanan analitik
+        val pageViews = 12345
+        val uniqueVisitors = 6789
+        val bounceRate = 54.3f
+        viewsText.text = getString(R.string.label_page_views) + ": $pageViews"
+        visitorsText.text = getString(R.string.label_unique_visitors) + ": $uniqueVisitors"
+        bounceText.text = getString(R.string.label_bounce_rate) + ": $bounceRate%"
+
+        val trending = listOf(
+            "Pencanangan Zona Integritas",
+            "Operasi Pengamanan Mudik",
+            "Penangkapan Kasus Narkoba"
+        )
+        trendingList.layoutManager = LinearLayoutManager(this)
+        trendingList.adapter = TrendingTopicAdapter(trending)
     }
 
     private fun showDatePicker(target: EditText) {

--- a/app/src/main/java/com/example/penmasnews/ui/TrendingTopicAdapter.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/TrendingTopicAdapter.kt
@@ -1,0 +1,29 @@
+package com.example.penmasnews.ui
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import com.example.penmasnews.R
+
+/** Adapter sederhana untuk menampilkan daftar topik tren. */
+class TrendingTopicAdapter(private val items: List<String>) :
+    RecyclerView.Adapter<TrendingTopicAdapter.ViewHolder>() {
+
+    class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+        val text: TextView = view.findViewById(android.R.id.text1)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(android.R.layout.simple_list_item_1, parent, false)
+        return ViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.text.text = items[position]
+    }
+
+    override fun getItemCount(): Int = items.size
+}

--- a/app/src/main/res/layout/activity_analytics_dashboard.xml
+++ b/app/src/main/res/layout/activity_analytics_dashboard.xml
@@ -22,6 +22,56 @@
             android:layout_height="wrap_content"
             android:lineSpacingExtra="2dp" />
 
+        <TextView
+            android:text="@string/label_site_metrics"
+            android:textStyle="bold"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingTop="12dp" />
+
+        <LinearLayout
+            android:id="@+id/layoutMetrics"
+            android:orientation="vertical"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            style="@style/ListFrame">
+
+            <TextView
+                android:id="@+id/textViews"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:padding="4dp"
+                android:text="@string/label_page_views" />
+
+            <TextView
+                android:id="@+id/textVisitors"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:padding="4dp"
+                android:text="@string/label_unique_visitors" />
+
+            <TextView
+                android:id="@+id/textBounce"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:padding="4dp"
+                android:text="@string/label_bounce_rate" />
+        </LinearLayout>
+
+        <TextView
+            android:text="@string/label_trending_topics"
+            android:textStyle="bold"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingTop="16dp" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerViewTrending"
+            android:layout_width="match_parent"
+            android:layout_height="150dp"
+            android:layout_marginTop="4dp"
+            style="@style/ListFrame" />
+
         <com.google.android.material.textfield.TextInputLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,6 +16,11 @@
     <string name="desc_workflow_manager">Memuat daftar draf dengan status draft, review, hingga final.\nSetiap entri dapat dibuka kembali di Penulisan Kolaboratif jika perlu revisi.\nSetelah disetujui, konten diteruskan ke Integrasi CMS.</string>
     <string name="desc_cms_integration">Menyediakan opsi publikasi ke situs web dan berbagai kanal sosial.\nSelesai publikasi, sistem mengarahkan pengguna untuk melihat Analitik.</string>
     <string name="desc_analytics_dashboard">Dashboard metrik performa artikel dan umpan balik pembaca.\nRekomendasi topik baru dapat langsung ditambahkan ke Kalender Editorial.</string>
+    <string name="label_site_metrics">Statistik Situs</string>
+    <string name="label_trending_topics">Topik Tren</string>
+    <string name="label_page_views">Tampilan Halaman</string>
+    <string name="label_unique_visitors">Pengunjung Unik</string>
+    <string name="label_bounce_rate">Bounce Rate</string>
     <!-- common form hints -->
     <string name="hint_date">Penjadwalan: Tanggal dan waktu publikasi yang direncanakan</string>
     <string name="hint_notes">Tambahkan Catatan</string>

--- a/docs/analytics_dashboard.md
+++ b/docs/analytics_dashboard.md
@@ -1,0 +1,22 @@
+# Halaman Analitik & Umpan Balik
+
+Dokumen ini merinci rancangan halaman analitik pada aplikasi **Penmas News**. Tujuannya menyediakan gambaran performa konten secara ringkas agar redaksi dapat mengambil keputusan berbasis data.
+
+## Tujuan
+- Menyajikan statistik utama seperti jumlah kunjungan dan tingkat keterlibatan pembaca.
+- Menampilkan daftar topik tren yang bisa dijadikan masukan agenda berita berikutnya.
+- Memudahkan pencatatan insight atau umpan balik dari audiens.
+
+## Komponen Tampilan
+1. **Statistik Situs** – berisi metrik kunci:
+   - *Tampilan Halaman* (page views)
+   - *Pengunjung Unik* (unique visitors)
+   - *Bounce Rate*
+2. **Topik Tren** – daftar singkat kata kunci atau artikel populer yang tengah dibicarakan.
+3. **Form Catatan** – kolom tanggal dan catatan untuk menyimpan insight penting.
+
+## Alur Singkat
+1. Setelah publikasi melalui modul **Integrasi CMS**, pengguna membuka halaman Analitik.
+2. Sistem menampilkan statistik terbaru dan daftar topik tren.
+3. Pengguna dapat menambahkan catatan serta tanggal untuk merekam insight tertentu.
+4. Rekomendasi topik yang dirasa relevan bisa langsung dimasukkan ke **Kalender Editorial** untuk direncanakan lebih lanjut.

--- a/docs/ui_overview.md
+++ b/docs/ui_overview.md
@@ -45,6 +45,7 @@ Dokumen ini memetakan rancangan halaman pada aplikasi Penmas News beserta alur p
 ## 8. Analitik & Umpan Balik
 - Dashboard metrik performa artikel dan umpan balik pembaca.
 - Rekomendasi topik baru dapat langsung ditambahkan ke **Kalender Editorial**.
+- Lihat rincian desain pada [dokumen khusus](analytics_dashboard.md).
 
 ### Alur Utama Pengguna
 1. Pengguna membuka **Beranda**.


### PR DESCRIPTION
## Summary
- design analytics and feedback page
- add trending topic adapter
- show placeholder metrics
- document analytics dashboard

## Testing
- `gradle assemble` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a497313c48327be85dfb7e10dd5de