### PR TITLE
Remove note fields from analytics

### DIFF
--- a/app/src/main/java/com/example/penmasnews/model/ChangeLogDatabase.kt
+++ b/app/src/main/java/com/example/penmasnews/model/ChangeLogDatabase.kt
@@ -57,7 +57,7 @@ object ChangeLogDatabase {
         val db = getHelper(context).readableDatabase
         val cursor = db.query(TABLE_NAME,
             arrayOf("user", "status", "changes", "timestamp"),
-            null, null, null, null, "timestamp ASC")
+            null, null, null, null, "timestamp DESC")
         cursor.use { c ->
             while (c.moveToNext()) {
                 list.add(

--- a/app/src/main/res/layout/activity_analytics_dashboard.xml
+++ b/app/src/main/res/layout/activity_analytics_dashboard.xml
@@ -72,37 +72,6 @@
             android:layout_marginTop="4dp"
             style="@style/ListFrame" />
 
-        <com.google.android.material.textfield.TextInputLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="@string/hint_date"
-            android:layout_marginTop="16dp">
-
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/editDate"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:focusable="false"
-                android:clickable="true" />
-        </com.google.android.material.textfield.TextInputLayout>
-
-        <com.google.android.material.textfield.TextInputLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="@string/hint_notes"
-            android:layout_marginTop="8dp">
-
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/editNotes"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
-        </com.google.android.material.textfield.TextInputLayout>
-
-        <Button
-            android:id="@+id/buttonSave"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/action_save"
-            android:layout_marginTop="8dp" />
+        <!-- Removed scheduling note fields and save button -->
     </LinearLayout>
 </ScrollView>

--- a/docs/analytics_dashboard.md
+++ b/docs/analytics_dashboard.md
@@ -13,10 +13,8 @@ Dokumen ini merinci rancangan halaman analitik pada aplikasi **Penmas News**. Tu
    - *Pengunjung Unik* (unique visitors)
    - *Bounce Rate*
 2. **Topik Tren** – daftar singkat kata kunci atau artikel populer yang tengah dibicarakan.
-3. **Form Catatan** – kolom tanggal dan catatan untuk menyimpan insight penting.
 
 ## Alur Singkat
 1. Setelah publikasi melalui modul **Integrasi CMS**, pengguna membuka halaman Analitik.
 2. Sistem menampilkan statistik terbaru dan daftar topik tren.
-3. Pengguna dapat menambahkan catatan serta tanggal untuk merekam insight tertentu.
-4. Rekomendasi topik yang dirasa relevan bisa langsung dimasukkan ke **Kalender Editorial** untuk direncanakan lebih lanjut.
+3. Rekomendasi topik yang dirasa relevan bisa langsung dimasukkan ke **Kalender Editorial** untuk direncanakan lebih lanjut.

--- a/docs/editorial_calendar.md
+++ b/docs/editorial_calendar.md
@@ -37,6 +37,7 @@ Modul ini menampilkan kalender harian, mingguan, atau bulanan yang memuat:
 
 ## Tampilan ListView
 
-Daftar agenda ditampilkan menggunakan gaya bingkai yang sama seperti halaman
-**Integrasi CMS**. Setiap baris memiliki garis tepi halus dan seluruh daftar
-dilingkupi frame serupa untuk konsistensi visual.
+Daftar agenda menggunakan gaya bingkai serupa dengan halaman **Integrasi CMS**.
+Setiap baris memiliki garis tepi halus dan warna selang-seling sehingga lebih
+mudah dipindai. Seluruh daftar juga dilingkupi frame agar konsisten secara
+visual.


### PR DESCRIPTION
## Summary
- remove date and notes form from Analytics page
- show newest log entries first
- document calendar list view styling
- update analytics docs for new layout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a4c0ee328832799975aa55371ee0e