### PR TITLE
Make log page use terminal style

### DIFF
--- a/app/src/main/java/com/example/penmasnews/ui/LogListAdapter.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/LogListAdapter.kt
@@ -5,6 +5,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
+import com.example.penmasnews.R
 import com.example.penmasnews.model.ChangeLogEntry
 import com.example.penmasnews.util.DateUtils
 
@@ -12,12 +13,12 @@ class LogListAdapter(private val items: List<ChangeLogEntry>) :
     RecyclerView.Adapter<LogListAdapter.ViewHolder>() {
 
     class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
-        val text: TextView = view.findViewById(android.R.id.text1)
+        val text: TextView = view.findViewById(R.id.textLog)
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         val view = LayoutInflater.from(parent.context)
-            .inflate(android.R.layout.simple_list_item_1, parent, false)
+            .inflate(R.layout.item_log_entry, parent, false)
         return ViewHolder(view)
     }
 

--- a/app/src/main/res/drawable/terminal_list_background.xml
+++ b/app/src/main/res/drawable/terminal_list_background.xml
@@ -1,0 +1,5 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="#000000"/>
+    <stroke android:width="1dp" android:color="#BDBDBD"/>
+    <corners android:radius="8dp"/>
+</shape>

--- a/app/src/main/res/layout/activity_log_data.xml
+++ b/app/src/main/res/layout/activity_log_data.xml
@@ -17,5 +17,5 @@
         android:id="@+id/recyclerViewLogs"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        style="@style/ListFrame" />
+        style="@style/TerminalListFrame" />
 </LinearLayout>

--- a/app/src/main/res/layout/item_log_entry.xml
+++ b/app/src/main/res/layout/item_log_entry.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/textLog"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="8dp"
+    android:textSize="12sp"
+    android:fontFamily="monospace"
+    android:textColor="#00FF00"
+    android:background="#000000" />

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -2,5 +2,10 @@
     <style name="ListFrame">
         <item name="android:background">@drawable/list_border</item>
         <item name="android:padding">4dp</item>
+</style>
+
+    <style name="TerminalListFrame">
+        <item name="android:background">@drawable/terminal_list_background</item>
+        <item name="android:padding">4dp</item>
     </style>
 </resources>


### PR DESCRIPTION
## Summary
- create custom layout for log entry items using monospace font with green text on black background
- apply new TerminalListFrame style to Log Data screen
- update LogListAdapter to use custom layout

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a563d9dd48327938f008562783fa5