### PR TITLE
Fix adapter initialization error

### DIFF
--- a/app/src/main/java/com/example/penmasnews/ui/ApprovalListActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/ApprovalListActivity.kt
@@ -19,7 +19,8 @@ class ApprovalListActivity : AppCompatActivity() {
         recyclerView.layoutManager = LinearLayoutManager(this)
 
         val items = mutableListOf<ApprovalItem>()
-        val adapter = ApprovalListAdapter(items) { item, action ->
+        lateinit var adapter: ApprovalListAdapter
+        adapter = ApprovalListAdapter(items) { item, action ->
             val authPrefs = getSharedPreferences("auth", MODE_PRIVATE)
             val token = authPrefs.getString("token", null)
             val user = authPrefs.getString("username", "unknown") ?: "unknown"


### PR DESCRIPTION
## Summary
- initialize `ApprovalListAdapter` using a `lateinit var` so the lambda can reference the adapter instance

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a5b7a10548327a22a5bcac1387bf8