### PR TITLE
Add word cloud analytics

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,4 +57,5 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.3.1'
     implementation 'com.squareup.okhttp3:okhttp:4.11.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
+    implementation 'com.google.android.flexbox:flexbox:3.0.0'
 }

--- a/app/src/main/java/com/example/penmasnews/network/AnalyticsService.kt
+++ b/app/src/main/java/com/example/penmasnews/network/AnalyticsService.kt
@@ -1,0 +1,52 @@
+package com.example.penmasnews.network
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+/**
+ * Utility service that fetches titles from Tribrata News RSS feed
+ * and generates word frequencies for a simple trend analysis.
+ */
+object AnalyticsService {
+    private val client = OkHttpClient()
+
+    private const val FEED_URL = "https://tribratanews.jatim.polri.go.id/feed"
+
+    /**
+     * Retrieve recent article titles from the RSS feed.
+     */
+    fun fetchTitles(): List<String> {
+        val request = Request.Builder().url(FEED_URL).build()
+        return try {
+            client.newCall(request).execute().use { resp ->
+                val body = resp.body?.string() ?: return emptyList()
+                // simple regex parse of <title> elements
+                Regex("<title>(.*?)</title>").findAll(body)
+                    .map { it.groupValues[1] }
+                    .drop(1) // skip channel title
+                    .toList()
+            }
+        } catch (_: Exception) {
+            emptyList()
+        }
+    }
+
+    /**
+     * Return a map of word -> frequency from recent titles.
+     */
+    fun fetchWordFrequency(): Map<String, Int> {
+        val titles = fetchTitles()
+        val freq = mutableMapOf<String, Int>()
+        val wordRegex = Regex("[A-Za-zÀ-ÿ']+")
+        for (t in titles) {
+            wordRegex.findAll(t.lowercase()).forEach {
+                val w = it.value
+                if (w.length < 3) return@forEach
+                freq[w] = (freq[w] ?: 0) + 1
+            }
+        }
+        return freq.entries.sortedByDescending { it.value }
+            .take(30)
+            .associate { it.toPair() }
+    }
+}

--- a/app/src/main/java/com/example/penmasnews/ui/AnalyticsDashboardActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/AnalyticsDashboardActivity.kt
@@ -6,7 +6,9 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.appcompat.app.AppCompatActivity
 import com.example.penmasnews.R
+import com.example.penmasnews.network.AnalyticsService
 import com.example.penmasnews.ui.TrendingTopicAdapter
+import com.example.penmasnews.ui.WordCloudView
 
 class AnalyticsDashboardActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -17,6 +19,7 @@ class AnalyticsDashboardActivity : AppCompatActivity() {
         val visitorsText = findViewById<TextView>(R.id.textVisitors)
         val bounceText = findViewById<TextView>(R.id.textBounce)
         val trendingList = findViewById<RecyclerView>(R.id.recyclerViewTrending)
+        val wordCloud = findViewById<WordCloudView>(R.id.wordCloud)
 
         // Placeholder angka metrik, seharusnya diambil dari layanan analitik
         val pageViews = 12345
@@ -26,12 +29,15 @@ class AnalyticsDashboardActivity : AppCompatActivity() {
         visitorsText.text = getString(R.string.label_unique_visitors) + ": $uniqueVisitors"
         bounceText.text = getString(R.string.label_bounce_rate) + ": $bounceRate%"
 
-        val trending = listOf(
-            "Pencanangan Zona Integritas",
-            "Operasi Pengamanan Mudik",
-            "Penangkapan Kasus Narkoba"
-        )
         trendingList.layoutManager = LinearLayoutManager(this)
-        trendingList.adapter = TrendingTopicAdapter(trending)
+
+        Thread {
+            val freq = AnalyticsService.fetchWordFrequency()
+            val topics = freq.keys.take(10).toList()
+            runOnUiThread {
+                trendingList.adapter = TrendingTopicAdapter(topics)
+                wordCloud.setWords(freq)
+            }
+        }.start()
     }
 }

--- a/app/src/main/java/com/example/penmasnews/ui/WordCloudView.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/WordCloudView.kt
@@ -1,0 +1,36 @@
+package com.example.penmasnews.ui
+
+import android.content.Context
+import android.util.AttributeSet
+import android.widget.TextView
+import com.google.android.flexbox.FlexboxLayout
+import kotlin.math.max
+
+/**
+ * Simple view that arranges words in a flexible layout with size
+ * based on frequency, creating a basic word cloud effect.
+ */
+class WordCloudView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null
+) : FlexboxLayout(context, attrs) {
+
+    /**
+     * Populate the view with words mapped to their occurrence counts.
+     */
+    fun setWords(freq: Map<String, Int>) {
+        removeAllViews()
+        if (freq.isEmpty()) return
+        val maxCount = freq.values.maxOrNull() ?: 1
+        for ((word, count) in freq) {
+            val tv = TextView(context)
+            val scale = 0.5f + count.toFloat() / max(1, maxCount)
+            tv.text = word
+            tv.textSize = 12f * scale
+            val m = (4 * resources.displayMetrics.density).toInt()
+            val lp = LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT)
+            lp.setMargins(m, m, m, m)
+            addView(tv, lp)
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_analytics_dashboard.xml
+++ b/app/src/main/res/layout/activity_analytics_dashboard.xml
@@ -72,6 +72,20 @@
             android:layout_marginTop="4dp"
             style="@style/ListFrame" />
 
+        <TextView
+            android:text="@string/label_word_cloud"
+            android:textStyle="bold"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingTop="16dp" />
+
+        <com.example.penmasnews.ui.WordCloudView
+            android:id="@+id/wordCloud"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            style="@style/ListFrame" />
+
         <!-- Removed scheduling note fields and save button -->
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="desc_analytics_dashboard">Dashboard metrik performa artikel dan umpan balik pembaca.\nRekomendasi topik baru dapat langsung ditambahkan ke Kalender Editorial.</string>
     <string name="label_site_metrics">Statistik Situs</string>
     <string name="label_trending_topics">Topik Tren</string>
+    <string name="label_word_cloud">Word Cloud</string>
     <string name="label_page_views">Tampilan Halaman</string>
     <string name="label_unique_visitors">Pengunjung Unik</string>
     <string name="label_bounce_rate">Bounce Rate</string>


### PR DESCRIPTION
## Summary
- fetch trending words from Tribrata News RSS feed
- display words using new `WordCloudView`
- show trending topics and word cloud on Analytics page
- add Flexbox dependency

## Testing
- `gradle build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a5b1d8a98832788b79e5e8c18197a