### PR TITLE
Fix variable scope in ApprovalListActivity

### DIFF
--- a/app/src/main/java/com/example/penmasnews/ui/ApprovalListActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/ApprovalListActivity.kt
@@ -11,6 +11,9 @@ import com.example.penmasnews.network.ApprovalService
 import com.example.penmasnews.network.EventService
 
 class ApprovalListActivity : AppCompatActivity() {
+    private val items = mutableListOf<ApprovalItem>()
+    private lateinit var adapter: ApprovalListAdapter
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_approval_list)
@@ -18,8 +21,6 @@ class ApprovalListActivity : AppCompatActivity() {
         val recyclerView = findViewById<RecyclerView>(R.id.recyclerViewApproval)
         recyclerView.layoutManager = LinearLayoutManager(this)
 
-        val items = mutableListOf<ApprovalItem>()
-        lateinit var adapter: ApprovalListAdapter
         adapter = ApprovalListAdapter(items) { item ->
             val intent = Intent(this, ApprovalDetailActivity::class.java)
             intent.putExtra("event", item.event)


### PR DESCRIPTION
## Summary
- make `items` and `adapter` class properties in ApprovalListActivity

## Testing
- `gradle` wrapper not present; no tests to run

------
https://chatgpt.com/codex/tasks/task_e_687a6197814c8327a5d858e20d420926