### PR TITLE
Implement remember login checkbox

### DIFF
--- a/app/src/main/java/com/example/penmasnews/ui/LoginActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/LoginActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.widget.Button
 import com.google.android.material.textfield.TextInputEditText
 import android.widget.Toast
+import android.widget.CheckBox
 import androidx.appcompat.app.AppCompatActivity
 import com.example.penmasnews.MainActivity
 import com.example.penmasnews.R
@@ -17,12 +18,31 @@ class LoginActivity : AppCompatActivity() {
 
         val editUsername = findViewById<TextInputEditText>(R.id.editUsername)
         val editPassword = findViewById<TextInputEditText>(R.id.editPassword)
+        val checkRemember = findViewById<CheckBox>(R.id.checkRememberLogin)
         val buttonLogin = findViewById<Button>(R.id.buttonLogin)
         val buttonSignup = findViewById<Button>(R.id.buttonSignup)
+
+        val prefs = getSharedPreferences("auth", MODE_PRIVATE)
+        if (prefs.getBoolean("remember_credentials", false)) {
+            editUsername.setText(prefs.getString("saved_username", ""))
+            editPassword.setText(prefs.getString("saved_password", ""))
+            checkRemember.isChecked = true
+        }
 
         buttonLogin.setOnClickListener {
             val username = editUsername.text.toString()
             val password = editPassword.text.toString()
+            val editor = prefs.edit()
+            if (checkRemember.isChecked) {
+                editor.putBoolean("remember_credentials", true)
+                editor.putString("saved_username", username)
+                editor.putString("saved_password", password)
+            } else {
+                editor.remove("remember_credentials")
+                editor.remove("saved_username")
+                editor.remove("saved_password")
+            }
+            editor.apply()
             Thread {
                 val result = AuthService.login(username, password)
                 runOnUiThread {

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -33,6 +33,13 @@
             android:singleLine="true" />
     </com.google.android.material.textfield.TextInputLayout>
 
+    <CheckBox
+        android:id="@+id/checkRememberLogin"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/label_remember_login"
+        android:layout_marginTop="8dp" />
+
     <Button
         android:id="@+id/buttonLogin"
         android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,6 +69,7 @@
     <string name="error_signup">Pendaftaran gagal</string>
     <string name="signup_success">Pendaftaran berhasil</string>
     <string name="hello_actor">Halo, %1$s</string>
+    <string name="label_remember_login">Simpan login</string>
 
     <string name="label_role">Role</string>
     <string-array name="role_array">


### PR DESCRIPTION
## Summary
- add a checkbox to save login credentials
- support remembering username and password in `LoginActivity`

## Testing
- `./gradlew test` *(fails: no gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_687a698fd6f48327a474134493771de9