### PR TITLE
Integrate Blogger sign‑in for publishing

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -58,4 +58,5 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:4.11.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
     implementation 'com.google.android.flexbox:flexbox:3.0.0'
+    implementation 'com.google.android.gms:play-services-auth:20.7.0'
 }

--- a/app/src/main/java/com/example/penmasnews/feature/BloggerAuth.kt
+++ b/app/src/main/java/com/example/penmasnews/feature/BloggerAuth.kt
@@ -1,0 +1,52 @@
+package com.example.penmasnews.feature
+
+import android.app.Activity
+import android.content.Intent
+import com.google.android.gms.auth.GoogleAuthUtil
+import com.google.android.gms.auth.api.signin.GoogleSignIn
+import com.google.android.gms.auth.api.signin.GoogleSignInAccount
+import com.google.android.gms.auth.api.signin.GoogleSignInClient
+import com.google.android.gms.auth.api.signin.GoogleSignInOptions
+import com.google.android.gms.common.api.Scope
+
+object BloggerAuth {
+    const val RC_SIGN_IN = 9001
+    private var client: GoogleSignInClient? = null
+
+    fun getClient(activity: Activity): GoogleSignInClient {
+        if (client == null) {
+            val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+                .requestEmail()
+                .requestScopes(Scope("https://www.googleapis.com/auth/blogger"))
+                .build()
+            client = GoogleSignIn.getClient(activity, gso)
+        }
+        return client!!
+    }
+
+    fun getSignedInAccount(activity: Activity): GoogleSignInAccount? {
+        return GoogleSignIn.getLastSignedInAccount(activity)
+    }
+
+    fun signIn(activity: Activity) {
+        val signInIntent: Intent = getClient(activity).signInIntent
+        activity.startActivityForResult(signInIntent, RC_SIGN_IN)
+    }
+
+    fun signOut(activity: Activity) {
+        getClient(activity).signOut()
+    }
+
+    fun getAuthToken(activity: Activity, account: GoogleSignInAccount): String? {
+        return try {
+            GoogleAuthUtil.getToken(
+                activity,
+                account.account,
+                "oauth2:https://www.googleapis.com/auth/blogger"
+            )
+        } catch (_: Exception) {
+            null
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `BloggerAuth` helper to manage Google sign-in and token retrieval
- extend `CMSIntegration` to accept OAuth token and embed post image
- update `EditorialCalendarActivity` to request login before publishing
- include Google Play Services Auth dependency

## Testing
- `gradle --version`
- `gradle assembleDebug -x lint --stacktrace` *(fails: Starting a Gradle Daemon)*

------
https://chatgpt.com/codex/tasks/task_e_687a7036b3e083279d761cc2d4c42753