### PR TITLE
Update documentation for OAuth2 Blogger integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ repository, build and run it using Android Studio with the SDK installed.
 
 Open the project in Android Studio to edit and run on a device or emulator.
 
-Create a `.env` file in the project root to supply your API keys:
+Create a `.env` file in the project root to supply your API keys.  These
+credentials are used when signing in with Google OAuth2 in order to publish
+approved articles to Blogspot:
 
 ```
 OPENAI_API_KEY=sk-...


### PR DESCRIPTION
## Summary
- document that the Blogger integration uses Google OAuth2
- remind users to keep Blogger API credentials in `.env`

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a72d1e4cc8327b861f43da2b9620a