### PR TITLE
Enable OAuth client IDs for Blogger

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 # Example .env file
 OPENAI_API_KEY=your-openai-key
+# Optional API key fallback (not required when OAuth token is used)
 BLOGGER_API_KEY=your-blogger-key
 BLOGGER_BLOG_ID=your-blog-id
+# OAuth 2.0 client ID for Blogger sign-in
+BLOGGER_CLIENT_ID=your-client-id
 # Base URL for the Cicero backend (without the trailing /api path)
 API_BASE_URL=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -23,12 +23,13 @@ repository, build and run it using Android Studio with the SDK installed.
 
 Open the project in Android Studio to edit and run on a device or emulator.
 
-Create a `.env` file in the project root to supply your API keys:
+Create a `.env` file in the project root to supply your API keys and OAuth client ID:
 
 ```
 OPENAI_API_KEY=sk-...
-BLOGGER_API_KEY=your-blogger-key
+BLOGGER_API_KEY=your-blogger-key  # optional
 BLOGGER_BLOG_ID=your-blog-id
+BLOGGER_CLIENT_ID=your-client-id
 ```
 An example file `.env.example` is provided.
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,6 +11,7 @@ if (envFile.exists()) {
 def openAiKey = envProps.getProperty('OPENAI_API_KEY', '')
 def bloggerKey = envProps.getProperty('BLOGGER_API_KEY', '')
 def bloggerBlogId = envProps.getProperty('BLOGGER_BLOG_ID', '')
+def bloggerClientId = envProps.getProperty('BLOGGER_CLIENT_ID', '')
 def apiBaseUrl = envProps.getProperty('API_BASE_URL', '') ?: envProps.getProperty('BACKEND_BASE_URL', '')
 
 android {
@@ -26,6 +27,7 @@ android {
         buildConfigField 'String', 'OPENAI_API_KEY', '"' + openAiKey + '"'
         buildConfigField 'String', 'BLOGGER_API_KEY', '"' + bloggerKey + '"'
         buildConfigField 'String', 'BLOGGER_BLOG_ID', '"' + bloggerBlogId + '"'
+        buildConfigField 'String', 'BLOGGER_CLIENT_ID', '"' + bloggerClientId + '"'
         buildConfigField 'String', 'API_BASE_URL', '"' + apiBaseUrl + '"'
         // keep old name for compatibility
         buildConfigField 'String', 'BACKEND_BASE_URL', '"' + apiBaseUrl + '"'

--- a/app/src/main/java/com/example/penmasnews/feature/BloggerAuth.kt
+++ b/app/src/main/java/com/example/penmasnews/feature/BloggerAuth.kt
@@ -3,6 +3,7 @@ package com.example.penmasnews.feature
 import android.app.Activity
 import android.content.Intent
 import com.google.android.gms.auth.GoogleAuthUtil
+import com.example.penmasnews.BuildConfig
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount
 import com.google.android.gms.auth.api.signin.GoogleSignInClient
@@ -15,11 +16,16 @@ object BloggerAuth {
 
     fun getClient(activity: Activity): GoogleSignInClient {
         if (client == null) {
-            val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+            val builder = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
                 .requestEmail()
                 .requestScopes(Scope("https://www.googleapis.com/auth/blogger"))
-                .build()
-            client = GoogleSignIn.getClient(activity, gso)
+
+            val clientId = BuildConfig.BLOGGER_CLIENT_ID
+            if (clientId.isNotBlank()) {
+                builder.requestIdToken(clientId)
+            }
+
+            client = GoogleSignIn.getClient(activity, builder.build())
         }
         return client!!
     }


### PR DESCRIPTION
## Summary
- add `BLOGGER_CLIENT_ID` config option
- request ID token using the configured client ID when signing into Blogger
- document OAuth setup in README and `.env.example`

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a75b00a0483278166d530eb767e26