### PR TITLE
Fix BloggerAuth token retrieval

### DIFF
--- a/app/src/main/java/com/example/penmasnews/feature/BloggerAuth.kt
+++ b/app/src/main/java/com/example/penmasnews/feature/BloggerAuth.kt
@@ -44,10 +44,11 @@ object BloggerAuth {
     }
 
     fun getAuthToken(activity: Activity, account: GoogleSignInAccount): String? {
+        val googleAccount = account.account ?: return null
         return try {
             GoogleAuthUtil.getToken(
                 activity,
-                account.account,
+                googleAccount,
                 "oauth2:https://www.googleapis.com/auth/blogger"
             )
         } catch (_: Exception) {


### PR DESCRIPTION
## Summary
- prevent null `Account` when requesting the Blogger OAuth token

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a7927dec08327a2c73228212eb350