### PR TITLE
Display raw OAuth error on sign-in failure

### DIFF
--- a/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
@@ -202,7 +202,9 @@ class EditorialCalendarActivity : AppCompatActivity() {
                 pendingPublish?.let { publishEvent(it, account!!) }
                 pendingPublish = null
             } else {
-                Toast.makeText(this, "Login gagal", Toast.LENGTH_SHORT).show()
+                val raw = task.exception?.message ?: task.exception?.toString()
+                val msg = "Login gagal" + if (raw != null) ": $raw" else ""
+                Toast.makeText(this, msg, Toast.LENGTH_LONG).show()
             }
         }
     }


### PR DESCRIPTION
## Summary
- show Google OAuth sign-in failure details in the toast message

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a83b0bda48327a322a094fa577a4d