### PR TITLE
Use AppAuth for Blogger OAuth

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,4 +61,5 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
     implementation 'com.google.android.flexbox:flexbox:3.0.0'
     implementation 'com.google.android.gms:play-services-auth:20.7.0'
+    implementation 'net.openid:appauth:0.11.1'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,6 +25,16 @@
         <activity android:name=".ui.ApprovalListActivity" />
         <activity android:name=".ui.ApprovalDetailActivity" />
         <activity android:name=".ui.SignupActivity" />
+        <activity
+            android:name="net.openid.appauth.RedirectUriReceiverActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="com.example.penmasnews" android:host="oauth2redirect" />
+            </intent-filter>
+        </activity>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/penmasnews/feature/BloggerAuth.kt
+++ b/app/src/main/java/com/example/penmasnews/feature/BloggerAuth.kt
@@ -2,64 +2,61 @@ package com.example.penmasnews.feature
 
 import android.app.Activity
 import android.content.Intent
-import com.google.android.gms.auth.GoogleAuthUtil
+import android.net.Uri
 import com.example.penmasnews.BuildConfig
 import com.example.penmasnews.util.DebugLogger
-import com.google.android.gms.auth.api.signin.GoogleSignIn
-import com.google.android.gms.auth.api.signin.GoogleSignInAccount
-import com.google.android.gms.auth.api.signin.GoogleSignInClient
-import com.google.android.gms.auth.api.signin.GoogleSignInOptions
-import com.google.android.gms.common.api.Scope
+import net.openid.appauth.AuthorizationException
+import net.openid.appauth.AuthorizationRequest
+import net.openid.appauth.AuthorizationResponse
+import net.openid.appauth.AuthorizationService
+import net.openid.appauth.AuthorizationServiceConfiguration
+import net.openid.appauth.AuthState
+import net.openid.appauth.ResponseTypeValues
 
 object BloggerAuth {
     const val RC_SIGN_IN = 9001
-    private var client: GoogleSignInClient? = null
 
-    fun getClient(activity: Activity): GoogleSignInClient {
-        if (client == null) {
-            val builder = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
-                .requestEmail()
-                .requestScopes(Scope("https://www.googleapis.com/auth/blogger"))
+    private val AUTH_ENDPOINT = Uri.parse("https://accounts.google.com/o/oauth2/v2/auth")
+    private val TOKEN_ENDPOINT = Uri.parse("https://oauth2.googleapis.com/token")
+    private val REDIRECT_URI = Uri.parse("com.example.penmasnews:/oauth2redirect")
 
-            val clientId = BuildConfig.BLOGGER_CLIENT_ID
-            if (clientId.isNotBlank()) {
-                builder.requestIdToken(clientId)
-            }
+    private var service: AuthorizationService? = null
+    private var authState: AuthState? = null
 
-            client = GoogleSignIn.getClient(activity, builder.build())
+    fun startLogin(activity: Activity, callback: (String?) -> Unit) {
+        DebugLogger.log(activity, "Starting OAuth login")
+        val config = AuthorizationServiceConfiguration(AUTH_ENDPOINT, TOKEN_ENDPOINT)
+        val request = AuthorizationRequest.Builder(
+            config,
+            BuildConfig.BLOGGER_CLIENT_ID,
+            ResponseTypeValues.CODE,
+            REDIRECT_URI
+        ).setScopes("https://www.googleapis.com/auth/blogger", "email")
+            .build()
+        service = AuthorizationService(activity)
+        val intent = service!!.getAuthorizationRequestIntent(request)
+        activity.startActivityForResult(intent, RC_SIGN_IN)
+    }
+
+    fun handleAuthResponse(activity: Activity, data: Intent?, callback: (String?) -> Unit) {
+        val resp = AuthorizationResponse.fromIntent(data!!)
+        val ex = AuthorizationException.fromIntent(data)
+        if (resp == null) {
+            DebugLogger.log(activity, "Authorization failed: ${ex?.message}")
+            callback(null)
+            return
         }
-        return client!!
-    }
-
-    fun getSignedInAccount(activity: Activity): GoogleSignInAccount? {
-        return GoogleSignIn.getLastSignedInAccount(activity)
-    }
-
-    fun signIn(activity: Activity) {
-        DebugLogger.log(activity, "Launching Google sign in")
-        val signInIntent: Intent = getClient(activity).signInIntent
-        activity.startActivityForResult(signInIntent, RC_SIGN_IN)
-    }
-
-    fun signOut(activity: Activity) {
-        DebugLogger.log(activity, "Signing out of Google")
-        getClient(activity).signOut()
-    }
-
-    fun getAuthToken(activity: Activity, account: GoogleSignInAccount): String? {
-        val googleAccount = account.account ?: return null
-        return try {
-            val token = GoogleAuthUtil.getToken(
-                activity,
-                googleAccount,
-                "oauth2:https://www.googleapis.com/auth/blogger"
-            )
-            DebugLogger.log(activity, "Retrieved token length: ${'$'}{token.length}")
-            token
-        } catch (e: Exception) {
-            DebugLogger.log(activity, "Token retrieval failed: ${'$'}{e.message}")
-            null
+        authState = AuthState(resp, ex)
+        val tokenRequest = resp.createTokenExchangeRequest()
+        service?.performTokenRequest(tokenRequest) { tokenResp, tokenEx ->
+            if (tokenResp != null) {
+                authState?.update(tokenResp, tokenEx)
+                DebugLogger.log(activity, "Retrieved token length: ${tokenResp.accessToken?.length}")
+                callback(tokenResp.accessToken)
+            } else {
+                DebugLogger.log(activity, "Token exchange failed: ${tokenEx?.message}")
+                callback(null)
+            }
         }
     }
 }
-


### PR DESCRIPTION
## Summary
- add AppAuth dependency
- register redirect activity for OAuth
- rewrite `BloggerAuth` to use AppAuth and return access token
- update `EditorialCalendarActivity` to start OAuth flow and publish using token

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a9010de3c832781d7a08581b74595