### PR TITLE
Fix missing AppAuth redirect scheme

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,6 +24,7 @@ android {
         targetSdk 34
         versionCode 1
         versionName '1.0'
+        manifestPlaceholders = [appAuthRedirectScheme: 'com.example.penmasnews']
         buildConfigField 'String', 'OPENAI_API_KEY', '"' + openAiKey + '"'
         buildConfigField 'String', 'BLOGGER_API_KEY', '"' + bloggerKey + '"'
         buildConfigField 'String', 'BLOGGER_BLOG_ID', '"' + bloggerBlogId + '"'


### PR DESCRIPTION
## Summary
- fix manifest placeholder for AppAuth library

## Testing
- `./gradlew test` *(fails: `bash: ./gradlew: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_687af6128ce08327ae8997290ad9cef7