### PR TITLE
Add WordPress publishing option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,5 +5,9 @@ BLOGGER_API_KEY=your-blogger-key
 BLOGGER_BLOG_ID=your-blog-id
 # OAuth 2.0 client ID for Blogger sign-in
 BLOGGER_CLIENT_ID=your-client-id
+# WordPress publishing credentials
+WORDPRESS_BASE_URL=https://your-wordpress-site.com
+WORDPRESS_USER=your-username
+WORDPRESS_APP_PASS=your-application-password
 # Base URL for the Cicero backend (without the trailing /api path)
 API_BASE_URL=http://localhost:3000

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,6 +12,9 @@ def openAiKey = envProps.getProperty('OPENAI_API_KEY', '')
 def bloggerKey = envProps.getProperty('BLOGGER_API_KEY', '')
 def bloggerBlogId = envProps.getProperty('BLOGGER_BLOG_ID', '')
 def bloggerClientId = envProps.getProperty('BLOGGER_CLIENT_ID', '')
+def wpBaseUrl = envProps.getProperty('WORDPRESS_BASE_URL', '')
+def wpUser = envProps.getProperty('WORDPRESS_USER', '')
+def wpAppPass = envProps.getProperty('WORDPRESS_APP_PASS', '')
 def apiBaseUrl = envProps.getProperty('API_BASE_URL', '') ?: envProps.getProperty('BACKEND_BASE_URL', '')
 
 android {
@@ -29,6 +32,9 @@ android {
         buildConfigField 'String', 'BLOGGER_API_KEY', '"' + bloggerKey + '"'
         buildConfigField 'String', 'BLOGGER_BLOG_ID', '"' + bloggerBlogId + '"'
         buildConfigField 'String', 'BLOGGER_CLIENT_ID', '"' + bloggerClientId + '"'
+        buildConfigField 'String', 'WORDPRESS_BASE_URL', '"' + wpBaseUrl + '"'
+        buildConfigField 'String', 'WORDPRESS_USER', '"' + wpUser + '"'
+        buildConfigField 'String', 'WORDPRESS_APP_PASS', '"' + wpAppPass + '"'
         buildConfigField 'String', 'API_BASE_URL', '"' + apiBaseUrl + '"'
         // keep old name for compatibility
         buildConfigField 'String', 'BACKEND_BASE_URL', '"' + apiBaseUrl + '"'

--- a/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarAdapter.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarAdapter.kt
@@ -18,6 +18,7 @@ class EditorialCalendarAdapter(
     private val onAiAssist: ((EditorialEvent, Int) -> Unit)? = null,
     private val onDelete: ((EditorialEvent, Int) -> Unit)? = null,
     private val onPublish: ((EditorialEvent, Int) -> Unit)? = null,
+    private val onPublishWordpress: ((EditorialEvent, Int) -> Unit)? = null,
 ) : RecyclerView.Adapter<EditorialCalendarAdapter.ViewHolder>() {
 
     class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
@@ -57,10 +58,16 @@ class EditorialCalendarAdapter(
             if (item.status == "approved") {
                 AlertDialog.Builder(holder.itemView.context)
                     .setTitle(R.string.dialog_actions)
-                    .setItems(arrayOf(
-                        holder.itemView.context.getString(R.string.action_publish_blogspot)
-                    )) { _, _ ->
-                        onPublish?.invoke(item, position)
+                    .setItems(
+                        arrayOf(
+                            holder.itemView.context.getString(R.string.action_publish_blogspot),
+                            holder.itemView.context.getString(R.string.action_publish_wordpress)
+                        )
+                    ) { _, which ->
+                        when (which) {
+                            0 -> onPublish?.invoke(item, position)
+                            1 -> onPublishWordpress?.invoke(item, position)
+                        }
                     }
                     .show()
             } else {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,6 +55,7 @@
     <string name="hint_generated_summary">Ringkasan Hasil AI</string>
     <string name="action_request_approval">Approval</string>
     <string name="action_publish_blogspot">Kirim ke Blogspot</string>
+    <string name="action_publish_wordpress">Kirim ke WordPress</string>
     <string name="label_news_type">Jenis Konten</string>
     <string-array name="news_type_array">
         <item>Pers Release</item>


### PR DESCRIPTION
## Summary
- support WordPress credentials in build configuration
- extend CMSIntegration to publish posts via WordPress API
- update EditorialCalendar list adapter with WordPress action
- add handler in EditorialCalendarActivity for WordPress publishing
- add WordPress strings and environment variables

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687afd35ece08327870e4b31560b9823