### PR TITLE
Show raw publish responses

### DIFF
--- a/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
@@ -6,6 +6,9 @@ import android.widget.Button
 import android.widget.EditText
 import android.widget.Toast
 import android.content.Intent
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
 import com.google.android.material.snackbar.Snackbar
 import com.example.penmasnews.model.EventStorage
 import com.example.penmasnews.model.ChangeLogEntry
@@ -202,7 +205,13 @@ class EditorialCalendarActivity : AppCompatActivity() {
                 val fallback = if (result.success) "Dipublikasikan" else "Gagal publish"
                 val msg = result.raw ?: fallback
                 DebugLogger.log(this, "Publish result: ${'$'}msg")
-                Toast.makeText(this, msg, Toast.LENGTH_SHORT).show()
+                val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                clipboard.setPrimaryClip(ClipData.newPlainText("publish_response", msg))
+                Snackbar.make(findViewById(android.R.id.content), msg, Snackbar.LENGTH_LONG)
+                    .setAction(R.string.action_copy) {
+                        clipboard.setPrimaryClip(ClipData.newPlainText("publish_response", msg))
+                    }
+                    .show()
             }
         }.start()
     }
@@ -227,7 +236,13 @@ class EditorialCalendarActivity : AppCompatActivity() {
                 val fallback = if (result.success) "Dipublikasikan" else "Gagal publish"
                 val msg = result.raw ?: fallback
                 DebugLogger.log(this, "WordPress publish result: ${'$'}msg")
-                Toast.makeText(this, msg, Toast.LENGTH_SHORT).show()
+                val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                clipboard.setPrimaryClip(ClipData.newPlainText("publish_response", msg))
+                Snackbar.make(findViewById(android.R.id.content), msg, Snackbar.LENGTH_LONG)
+                    .setAction(R.string.action_copy) {
+                        clipboard.setPrimaryClip(ClipData.newPlainText("publish_response", msg))
+                    }
+                    .show()
             }
         }.start()
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,6 +47,7 @@
     <string name="action_view_logs">Lihat Log</string>
     <string name="action_paste">Tempel</string>
     <string name="action_clear">Bersihkan</string>
+    <string name="action_copy">Salin</string>
     <string name="dialog_actions">Tindakan</string>
     <string name="action_delete">Hapus List</string>
     <string name="hint_suggested_title">Saran Judul Berita</string>


### PR DESCRIPTION
## Summary
- show Blogger/WordPress publish responses on the Editorial Calendar page
- add a "Copy" action and clipboard support for debugging

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b10ee8210832799796f856cea9c98