### PR TITLE
Fix missing URL scheme

### DIFF
--- a/app/src/main/java/com/example/penmasnews/feature/CMSIntegration.kt
+++ b/app/src/main/java/com/example/penmasnews/feature/CMSIntegration.kt
@@ -9,6 +9,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Credentials
 import okhttp3.RequestBody.Companion.toRequestBody
+import com.example.penmasnews.util.UrlUtils
 import org.json.JSONObject
 
 /**
@@ -30,7 +31,9 @@ class CMSIntegration(
     private val wpAppPass: String
 
     init {
-        wpBaseUrl = CMSPrefs.getWordpressBaseUrl(ctx) ?: defaultWpBaseUrl
+        wpBaseUrl = UrlUtils.ensureHttpScheme(
+            CMSPrefs.getWordpressBaseUrl(ctx) ?: defaultWpBaseUrl
+        )
         wpUser = CMSPrefs.getWordpressUser(ctx) ?: defaultWpUser
         wpAppPass = CMSPrefs.getWordpressAppPass(ctx) ?: defaultWpAppPass
     }
@@ -88,7 +91,8 @@ class CMSIntegration(
     fun publishToWordpress(event: EditorialEvent): PublishResult {
         if (wpBaseUrl.isBlank()) return PublishResult(false, null)
 
-        val url = wpBaseUrl.trimEnd('/') + "/wp-json/wp/v2/posts"
+        val base = UrlUtils.ensureHttpScheme(wpBaseUrl)
+        val url = base.trimEnd('/') + "/wp-json/wp/v2/posts"
 
         val obj = JSONObject()
         obj.put("title", event.topic)

--- a/app/src/main/java/com/example/penmasnews/feature/WordpressAuth.kt
+++ b/app/src/main/java/com/example/penmasnews/feature/WordpressAuth.kt
@@ -3,13 +3,15 @@ package com.example.penmasnews.feature
 import android.content.Context
 import com.example.penmasnews.model.CMSPrefs
 import com.example.penmasnews.util.DebugLogger
+import com.example.penmasnews.util.UrlUtils
 import okhttp3.*
 import org.json.JSONObject
 import java.io.IOException
 
 object WordpressAuth {
     fun login(context: Context, baseUrl: String, user: String, pass: String, callback: (String?) -> Unit) {
-        val url = baseUrl.trimEnd('/') + "/wp-json/jwt-auth/v1/token"
+        val normalized = UrlUtils.ensureHttpScheme(baseUrl)
+        val url = normalized.trimEnd('/') + "/wp-json/jwt-auth/v1/token"
         val form = FormBody.Builder()
             .add("username", user)
             .add("password", pass)

--- a/app/src/main/java/com/example/penmasnews/ui/WordpressLoginActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/WordpressLoginActivity.kt
@@ -8,6 +8,7 @@ import androidx.appcompat.app.AppCompatActivity
 import com.example.penmasnews.R
 import com.example.penmasnews.model.CMSPrefs
 import com.example.penmasnews.feature.WordpressAuth
+import com.example.penmasnews.util.UrlUtils
 
 class WordpressLoginActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -24,7 +25,7 @@ class WordpressLoginActivity : AppCompatActivity() {
         CMSPrefs.getWordpressAppPass(this)?.let { editPass.setText(it) }
 
         button.setOnClickListener {
-            val base = editBase.text.toString()
+            val base = UrlUtils.ensureHttpScheme(editBase.text.toString())
             val user = editUser.text.toString()
             val pass = editPass.text.toString()
             WordpressAuth.login(this, base, user, pass) { token ->

--- a/app/src/main/java/com/example/penmasnews/util/UrlUtils.kt
+++ b/app/src/main/java/com/example/penmasnews/util/UrlUtils.kt
@@ -1,0 +1,14 @@
+package com.example.penmasnews.util
+
+/** Helpers for normalizing user provided URLs. */
+object UrlUtils {
+    /** Ensure the given URL starts with an http or https scheme. */
+    fun ensureHttpScheme(raw: String): String {
+        val trimmed = raw.trim()
+        return if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) {
+            trimmed
+        } else {
+            "https://$trimmed"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `UrlUtils` helper for normalizing URLs
- use `UrlUtils` in WordPress login and publishing flows
- ensure base URL stored from login screen always has a scheme

## Testing
- `gradle -version`

------
https://chatgpt.com/codex/tasks/task_e_687b1c89c3788327999ad8333c795bb8