### PR TITLE
Fix WordPress login with app passwords

### DIFF
--- a/app/src/main/java/com/example/penmasnews/feature/WordpressAuth.kt
+++ b/app/src/main/java/com/example/penmasnews/feature/WordpressAuth.kt
@@ -35,4 +35,25 @@ object WordpressAuth {
             }
         })
     }
+
+    fun verifyAppPassword(context: Context, baseUrl: String, user: String, appPass: String, callback: (Boolean) -> Unit) {
+        val normalized = UrlUtils.ensureHttpScheme(baseUrl)
+        val url = normalized.trimEnd('/') + "/wp-json/wp/v2/users/me"
+        val credential = Credentials.basic(user, appPass)
+        val request = Request.Builder()
+            .url(url)
+            .header("Authorization", credential)
+            .get()
+            .build()
+        OkHttpClient().newCall(request).enqueue(object : Callback {
+            override fun onFailure(call: Call, e: IOException) {
+                DebugLogger.log(context, "WordPress verify failed: ${'$'}{e.message}")
+                callback(false)
+            }
+
+            override fun onResponse(call: Call, response: Response) {
+                callback(response.isSuccessful)
+            }
+        })
+    }
 }

--- a/app/src/main/java/com/example/penmasnews/ui/WordpressLoginActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/WordpressLoginActivity.kt
@@ -28,10 +28,10 @@ class WordpressLoginActivity : AppCompatActivity() {
             val base = UrlUtils.ensureHttpScheme(editBase.text.toString())
             val user = editUser.text.toString()
             val pass = editPass.text.toString()
-            WordpressAuth.login(this, base, user, pass) { token ->
+            WordpressAuth.verifyAppPassword(this, base, user, pass) { ok ->
                 runOnUiThread {
-                    if (token != null) {
-                        CMSPrefs.saveWordpressCredentials(this, base, user, "")
+                    if (ok) {
+                        CMSPrefs.saveWordpressCredentials(this, base, user, pass)
                         Toast.makeText(this, R.string.message_login_success, Toast.LENGTH_LONG).show()
                         setResult(RESULT_OK)
                         finish()


### PR DESCRIPTION
## Summary
- implement a helper to verify WordPress Application Passwords
- login screen now stores the app password after verifying credentials

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b1ec3cfa88327a65aea0c15cceee7