### PR TITLE
Add log viewer to WordPress login

### DIFF
--- a/app/src/main/java/com/example/penmasnews/ui/WordpressLoginActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/WordpressLoginActivity.kt
@@ -4,10 +4,19 @@ import android.os.Bundle
 import android.widget.Button
 import com.google.android.material.textfield.TextInputEditText
 import android.widget.Toast
+import android.widget.TextView
+import android.widget.ScrollView
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import com.example.penmasnews.R
 import com.example.penmasnews.model.CMSPrefs
 import com.example.penmasnews.feature.WordpressAuth
+import com.example.penmasnews.util.DebugLogger
 import com.example.penmasnews.util.UrlUtils
 
 class WordpressLoginActivity : AppCompatActivity() {
@@ -19,10 +28,21 @@ class WordpressLoginActivity : AppCompatActivity() {
         val editUser = findViewById<TextInputEditText>(R.id.editWpUser)
         val editPass = findViewById<TextInputEditText>(R.id.editWpAppPass)
         val button = findViewById<Button>(R.id.buttonWpLogin)
+        val logView = findViewById<TextView>(R.id.textWpLog)
+        val logScroll = findViewById<ScrollView>(R.id.logScrollView)
+        val copyButton = findViewById<Button>(R.id.buttonCopyWpLog)
+        val viewButton = findViewById<Button>(R.id.buttonViewWpLog)
 
         CMSPrefs.getWordpressBaseUrl(this)?.let { editBase.setText(it) }
         CMSPrefs.getWordpressUser(this)?.let { editUser.setText(it) }
         CMSPrefs.getWordpressAppPass(this)?.let { editPass.setText(it) }
+
+        fun refreshLog() {
+            logView.text = DebugLogger.readLog(this)
+            logScroll.post { logScroll.fullScroll(View.FOCUS_DOWN) }
+        }
+
+        refreshLog()
 
         button.setOnClickListener {
             val base = UrlUtils.ensureHttpScheme(editBase.text.toString())
@@ -38,7 +58,27 @@ class WordpressLoginActivity : AppCompatActivity() {
                     } else {
                         Toast.makeText(this, R.string.message_login_failed, Toast.LENGTH_LONG).show()
                     }
+                    refreshLog()
                 }
+            }
+        }
+
+        copyButton.setOnClickListener {
+            val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+            val clip = ClipData.newPlainText("log", logView.text)
+            clipboard.setPrimaryClip(clip)
+            Toast.makeText(this, R.string.message_log_copied, Toast.LENGTH_SHORT).show()
+        }
+
+        viewButton.setOnClickListener {
+            val log = logView.text.toString()
+            val regex = "https?://\\S+\\.h?html".toRegex()
+            val match = regex.find(log)
+            if (match != null) {
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(match.value))
+                startActivity(intent)
+            } else {
+                Toast.makeText(this, R.string.message_no_html_log, Toast.LENGTH_LONG).show()
             }
         }
     }

--- a/app/src/main/res/layout/activity_wordpress_login.xml
+++ b/app/src/main/res/layout/activity_wordpress_login.xml
@@ -51,4 +51,41 @@
         android:layout_height="wrap_content"
         android:text="@string/action_login"
         android:layout_marginTop="16dp" />
+
+    <ScrollView
+        android:id="@+id/logScrollView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:layout_marginTop="16dp">
+
+        <TextView
+            android:id="@+id/textWpLog"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textSize="12sp"
+            android:textColor="@android:color/black"
+            android:textIsSelectable="true"
+            android:padding="4dp" />
+    </ScrollView>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/buttonCopyWpLog"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/action_copy" />
+
+        <Button
+            android:id="@+id/buttonViewWpLog"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/action_view_in_browser" />
+    </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -100,4 +100,7 @@
     <string name="label_wp_app_password">Application Password</string>
     <string name="message_login_success">Login berhasil</string>
     <string name="message_login_failed">Login gagal</string>
+    <string name="action_view_in_browser">Buka di Web</string>
+    <string name="message_no_html_log">Tidak ada tautan HTML pada log</string>
+    <string name="message_log_copied">Log telah disalin</string>
 </resources>


### PR DESCRIPTION
## Summary
- show login attempt logs beneath the WordPress login form
- allow copying the log or opening an HTML link found in the log

## Testing
- `./gradlew test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687b21df800c8327bacaf2e88abc8a1b