### PR TITLE
Log WordPress login responses

### DIFF
--- a/app/src/main/java/com/example/penmasnews/feature/WordpressAuth.kt
+++ b/app/src/main/java/com/example/penmasnews/feature/WordpressAuth.kt
@@ -25,6 +25,7 @@ object WordpressAuth {
 
             override fun onResponse(call: Call, response: Response) {
                 val bodyStr = response.body?.string()
+                DebugLogger.log(context, "WordPress login response: ${'$'}{bodyStr ?: "null"}")
                 val token = try {
                     JSONObject(bodyStr ?: "{}").getString("token")
                 } catch (_: Exception) { null }
@@ -52,6 +53,8 @@ object WordpressAuth {
             }
 
             override fun onResponse(call: Call, response: Response) {
+                val bodyStr = response.body?.string()
+                DebugLogger.log(context, "WordPress verify response: ${'$'}{bodyStr ?: "null"}")
                 callback(response.isSuccessful)
             }
         })


### PR DESCRIPTION
## Summary
- show server responses in `WordpressAuth`

## Testing
- `gradle tasks --quiet` *(fails: no such file)*

------
https://chatgpt.com/codex/tasks/task_e_687b24c8be9c832786b1bf52c85ae1f9