### PR TITLE
Fix DebugLogger calls in WordpressAuth

### DIFF
--- a/app/src/main/java/com/example/penmasnews/feature/WordpressAuth.kt
+++ b/app/src/main/java/com/example/penmasnews/feature/WordpressAuth.kt
@@ -19,13 +19,13 @@ object WordpressAuth {
         val request = Request.Builder().url(url).post(form).build()
         OkHttpClient().newCall(request).enqueue(object : Callback {
             override fun onFailure(call: Call, e: IOException) {
-                DebugLogger.log(context, "WordPress login failed: ${'$'}{e.message}")
+                DebugLogger.log(context, "WordPress login failed: ${e.message}")
                 callback(null)
             }
 
             override fun onResponse(call: Call, response: Response) {
                 val bodyStr = response.body?.string()
-                DebugLogger.log(context, "WordPress login response: ${'$'}{bodyStr ?: "null"}")
+                DebugLogger.log(context, "WordPress login response: ${bodyStr ?: "null"}")
                 val token = try {
                     JSONObject(bodyStr ?: "{}").getString("token")
                 } catch (_: Exception) { null }


### PR DESCRIPTION
## Summary
- fix string templates in `WordpressAuth` log statements

## Testing
- `gradlew` not found, so no tests run

------
https://chatgpt.com/codex/tasks/task_e_687b2636cb908327b288d880ab2cfba2