### PR TITLE
Implement WordPress session manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,4 @@ catatan, dan masukan teks, disediakan kolom untuk mengisi:
 - [Desain Halaman & Relasi Fitur](docs/ui_overview.md)
 - [Panduan Format Tanggal](docs/timestamp_usage.md)
 - [Halaman Analitik](docs/analytics_dashboard.md)
+- [Manajemen Login WordPress](docs/wordpress_session.md)

--- a/app/src/main/java/com/example/penmasnews/feature/CMSIntegration.kt
+++ b/app/src/main/java/com/example/penmasnews/feature/CMSIntegration.kt
@@ -10,6 +10,7 @@ import okhttp3.Request
 import okhttp3.Credentials
 import okhttp3.RequestBody.Companion.toRequestBody
 import com.example.penmasnews.util.UrlUtils
+import com.example.penmasnews.feature.WordpressAuth
 import org.json.JSONObject
 
 /**
@@ -105,7 +106,10 @@ class CMSIntegration(
             .url(url)
             .post(body)
 
-        val token = CMSPrefs.getWordpressToken(ctx)
+        var token = CMSPrefs.getWordpressToken(ctx)
+        if (token.isNullOrBlank() && wpUser.isNotBlank() && wpAppPass.isNotBlank()) {
+            token = WordpressAuth.loginBlocking(ctx, wpBaseUrl, wpUser, wpAppPass)
+        }
         if (!token.isNullOrBlank()) {
             builder.header("Authorization", "Bearer ${'$'}token")
         } else if (wpUser.isNotBlank() && wpAppPass.isNotBlank()) {

--- a/docs/wordpress_session.md
+++ b/docs/wordpress_session.md
@@ -1,0 +1,15 @@
+# Manajemen Login WordPress
+
+Dokumen ini menjelaskan cara kerja sesi login WordPress pada aplikasi **Penmas News** dan bagaimana sesi dibuat ulang secara otomatis.
+
+## Tujuan
+- Mempermudah proses publikasi dari kalender editorial.
+- Menghindari pengisian ulang kredensial setiap saat.
+
+## Alur
+1. Pengguna memasukkan **Base URL**, **Username**, dan **Application Password** pada halaman login WordPress.
+2. Aplikasi menyimpan data tersebut di `CMSPrefs`.
+3. Saat akan mempublikasikan ke WordPress, `CMSIntegration` memanggil `WordpressAuth.loginBlocking()` jika token belum ada.
+4. Token JWT yang diterima disimpan dan dipakai pada header `Authorization` tiap publikasi berikutnya.
+
+Dengan mekanisme ini workflow publikasi berjalan tanpa perlu login berulang kali.


### PR DESCRIPTION
## Summary
- add blocking WordPress login helper
- reuse helper in CMS integration so session is recreated automatically
- document WordPress login session behaviour

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b98a5c69483278d12f15e59c176a3