### PR TITLE
Update editorial calendar form

### DIFF
--- a/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.widget.Button
 import android.widget.EditText
 import android.widget.Toast
+import android.widget.Spinner
 import android.content.Intent
 import android.content.ClipData
 import android.content.ClipboardManager
@@ -40,7 +41,8 @@ class EditorialCalendarActivity : AppCompatActivity() {
         recyclerView.layoutManager = LinearLayoutManager(this)
 
         val dateEdit = findViewById<EditText>(R.id.editDate)
-        val topicEdit = findViewById<EditText>(R.id.editTopic)
+        val topicSpinner = findViewById<android.widget.Spinner>(R.id.spinnerTopic)
+        val notesEdit = findViewById<EditText>(R.id.editNotes)
         val assigneeEdit = findViewById<EditText>(R.id.editAssignee)
         val addButton = findViewById<Button>(R.id.buttonAddEvent)
 
@@ -131,11 +133,11 @@ class EditorialCalendarActivity : AppCompatActivity() {
             val creator = authPrefs.getString("username", "") ?: ""
             val event = EditorialEvent(
                 dateEdit.text.toString(),
-                topicEdit.text.toString(),
+                topicSpinner.selectedItem.toString(),
                 assignee,
                 status,
                 "",
-                "",
+                notesEdit.text.toString(),
                 "",
                 0,
                 DateUtils.now(),
@@ -164,7 +166,8 @@ class EditorialCalendarActivity : AppCompatActivity() {
                         }.start()
                     }
                     dateEdit.text.clear()
-                    topicEdit.text.clear()
+                    notesEdit.text.clear()
+                    topicSpinner.setSelection(0)
                     assigneeEdit.text.clear()
                 }
             }.start()

--- a/app/src/main/res/layout/activity_editorial_calendar.xml
+++ b/app/src/main/res/layout/activity_editorial_calendar.xml
@@ -43,14 +43,22 @@
                 android:clickable="true" />
         </com.google.android.material.textfield.TextInputLayout>
 
+        <Spinner
+            android:id="@+id/spinnerTopic"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:entries="@array/news_type_array"
+            android:prompt="@string/label_news_type"
+            android:layout_marginTop="8dp" />
+
         <com.google.android.material.textfield.TextInputLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="@string/hint_topic"
+            android:hint="@string/hint_notes"
             android:layout_marginTop="8dp">
 
             <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/editTopic"
+                android:id="@+id/editNotes"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
         </com.google.android.material.textfield.TextInputLayout>


### PR DESCRIPTION
## Summary
- replace text topic field with spinner using existing list of news types
- add notes field below topic spinner

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bb4ac8a3c8327a5aa6dd7358a429e