### PR TITLE
Fix missing API base URL check in editorial calendar

### DIFF
--- a/app/src/main/java/com/example/penmasnews/model/EventStorage.kt
+++ b/app/src/main/java/com/example/penmasnews/model/EventStorage.kt
@@ -2,6 +2,7 @@ package com.example.penmasnews.model
 
 import android.content.Context
 import com.example.penmasnews.network.EventService
+import com.example.penmasnews.BuildConfig
 
 /** Utility object for persisting editorial events in SharedPreferences. */
 object EventStorage {
@@ -10,12 +11,14 @@ object EventStorage {
     fun loadEvents(context: Context): MutableList<EditorialEvent> {
         val auth = context.getSharedPreferences("auth", Context.MODE_PRIVATE)
         val token = auth.getString("token", null) ?: return mutableListOf()
+        if (BuildConfig.API_BASE_URL.isBlank()) return mutableListOf()
         return EventService.fetchEvents(token).toMutableList()
     }
 
     fun addEvent(context: Context, event: EditorialEvent): EditorialEvent? {
         val auth = context.getSharedPreferences("auth", Context.MODE_PRIVATE)
         val token = auth.getString("token", null) ?: return null
+        if (BuildConfig.API_BASE_URL.isBlank()) return null
         return EventService.createEvent(token, event)
     }
 

--- a/app/src/main/java/com/example/penmasnews/network/EventService.kt
+++ b/app/src/main/java/com/example/penmasnews/network/EventService.kt
@@ -15,7 +15,9 @@ object EventService {
     private val jsonType = "application/json; charset=utf-8".toMediaType()
 
     fun fetchEvents(token: String): List<EditorialEvent> {
-        val url = BuildConfig.API_BASE_URL.trimEnd('/') + "/api/events"
+        val base = BuildConfig.API_BASE_URL.trimEnd('/')
+        if (base.isBlank()) return emptyList()
+        val url = base + "/api/events"
         val request = Request.Builder()
             .url(url)
             .header("Authorization", "Bearer $token")
@@ -67,7 +69,9 @@ object EventService {
     }
 
     fun createEvent(token: String, event: EditorialEvent): EditorialEvent? {
-        val url = BuildConfig.API_BASE_URL.trimEnd('/') + "/api/events"
+        val base = BuildConfig.API_BASE_URL.trimEnd('/')
+        if (base.isBlank()) return null
+        val url = base + "/api/events"
         val obj = JSONObject()
         obj.put("event_date", event.date)
         obj.put("topic", event.topic)
@@ -124,7 +128,9 @@ object EventService {
     }
 
     fun updateEvent(token: String, id: Int, event: EditorialEvent): Boolean {
-        val url = BuildConfig.API_BASE_URL.trimEnd('/') + "/api/events/$id"
+        val base = BuildConfig.API_BASE_URL.trimEnd('/')
+        if (base.isBlank()) return false
+        val url = base + "/api/events/$id"
         val obj = JSONObject()
         obj.put("event_date", event.date)
         obj.put("topic", event.topic)
@@ -150,7 +156,9 @@ object EventService {
     }
 
     fun deleteEvent(token: String, id: Int): Boolean {
-        val url = BuildConfig.API_BASE_URL.trimEnd('/') + "/api/events/$id"
+        val base = BuildConfig.API_BASE_URL.trimEnd('/')
+        if (base.isBlank()) return false
+        val url = base + "/api/events/$id"
         val request = Request.Builder()
             .url(url)
             .delete()

--- a/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
@@ -151,6 +151,13 @@ class EditorialCalendarActivity : AppCompatActivity() {
                 val created = EventStorage.addEvent(this, event)
                 val loaded = EventStorage.loadEvents(this)
                 runOnUiThread {
+                    if (created == null) {
+                        Toast.makeText(
+                            this,
+                            "API_BASE_URL tidak dikonfigurasi",
+                            Toast.LENGTH_LONG
+                        ).show()
+                    }
                     events.clear()
                     events.addAll(loaded)
                     adapter.notifyDataSetChanged()


### PR DESCRIPTION
## Summary
- ensure EventService methods return early when `API_BASE_URL` is empty
- guard EventStorage operations with a base URL check
- show a toast in `EditorialCalendarActivity` when the API base URL isn't configured

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ce8b392a88327a8eee9b7ae2858cc