### PR TITLE
Update schema to drop username column

### DIFF
--- a/cicero_sql/schema.sql
+++ b/cicero_sql/schema.sql
@@ -283,7 +283,6 @@ CREATE TABLE IF NOT EXISTS editorial_event (
   kategori TEXT,
   created_by TEXT REFERENCES penmas_user(user_id),
   updated_by TEXT REFERENCES penmas_user(user_id),
-  username TEXT,
   created_at TIMESTAMP DEFAULT NOW(),
   last_update TIMESTAMP DEFAULT NOW()
 );

--- a/docs/postgresql_schema.sql
+++ b/docs/postgresql_schema.sql
@@ -11,8 +11,8 @@ CREATE TABLE IF NOT EXISTS editorial_event (
   image_path TEXT,
   tag TEXT,
   kategori TEXT,
-  created_by TEXT REFERENCES penmas_user(username),
-  updated_by TEXT REFERENCES penmas_user(username),
+  created_by TEXT REFERENCES penmas_user(user_id),
+  updated_by TEXT REFERENCES penmas_user(user_id),
   created_at TIMESTAMP DEFAULT NOW(),
   last_update TIMESTAMP DEFAULT NOW()
 );


### PR DESCRIPTION
## Summary
- remove `username` column from `editorial_event` table
- update documentation to reference `user_id` foreign keys

## Testing
- `npm run lint` *(fails: Could not read package.json)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687cebee3eb88327b84f4aaec7a3ebb7