### PR TITLE
Update API base URL handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,12 @@ OPENAI_API_KEY=sk-...
 BLOGGER_API_KEY=your-blogger-key  # optional
 BLOGGER_BLOG_ID=your-blog-id
 BLOGGER_CLIENT_ID=your-client-id
+API_BASE_URL=http://localhost:3000
 ```
 An example file `.env.example` is provided.
+
+`API_BASE_URL` controls which backend instance the app uses. The default
+`http://localhost:3000` works when running the included Node.js server.
 
 If OAuth login fails after choosing an account, ensure `BLOGGER_CLIENT_ID` matches the OAuth 2.0 client configured for your Android package and SHA1. Runtime logs can be inspected via Android Studio's Logcat.
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,14 +8,19 @@ def envFile = rootProject.file('.env')
 if (envFile.exists()) {
     envFile.withInputStream { envProps.load(it) }
 }
-def openAiKey = envProps.getProperty('OPENAI_API_KEY', '')
-def bloggerKey = envProps.getProperty('BLOGGER_API_KEY', '')
-def bloggerBlogId = envProps.getProperty('BLOGGER_BLOG_ID', '')
-def bloggerClientId = envProps.getProperty('BLOGGER_CLIENT_ID', '')
-def wpBaseUrl = envProps.getProperty('WORDPRESS_BASE_URL', '')
-def wpUser = envProps.getProperty('WORDPRESS_USER', '')
-def wpAppPass = envProps.getProperty('WORDPRESS_APP_PASS', '')
-def apiBaseUrl = envProps.getProperty('API_BASE_URL', '') ?: envProps.getProperty('BACKEND_BASE_URL', '')
+
+def env = { name ->
+    System.getenv(name) ?: envProps.getProperty(name, '')
+}
+
+def openAiKey = env('OPENAI_API_KEY')
+def bloggerKey = env('BLOGGER_API_KEY')
+def bloggerBlogId = env('BLOGGER_BLOG_ID')
+def bloggerClientId = env('BLOGGER_CLIENT_ID')
+def wpBaseUrl = env('WORDPRESS_BASE_URL')
+def wpUser = env('WORDPRESS_USER')
+def wpAppPass = env('WORDPRESS_APP_PASS')
+def apiBaseUrl = env('API_BASE_URL') ?: env('BACKEND_BASE_URL') ?: 'http://localhost:3000'
 
 android {
     namespace 'com.example.penmasnews'


### PR DESCRIPTION
## Summary
- load environment variables from the shell or `.env`
- set a default `API_BASE_URL`
- document `API_BASE_URL` in the README

## Testing
- `npm run lint` *(fails: could not find package.json)*
- `npm test` *(not run: no Node project)*


------
https://chatgpt.com/codex/tasks/task_e_687cfb74446c832784b29970ecca667c