### PR TITLE
Add news title field

### DIFF
--- a/app/src/main/java/com/example/penmasnews/feature/CMSIntegration.kt
+++ b/app/src/main/java/com/example/penmasnews/feature/CMSIntegration.kt
@@ -53,7 +53,7 @@ class CMSIntegration(
 
         val obj = JSONObject()
         obj.put("kind", "blogger#post")
-        obj.put("title", event.topic)
+        obj.put("title", event.title)
 
         val contentBuilder = StringBuilder()
         if (event.imagePath.isNotBlank()) {
@@ -96,7 +96,7 @@ class CMSIntegration(
         val url = base.trimEnd('/') + "/wp-json/wp/v2/posts"
 
         val obj = JSONObject()
-        obj.put("title", event.topic)
+        obj.put("title", event.title)
         obj.put("status", "publish")
         obj.put("content", if (event.content.isNotBlank()) event.content else event.summary)
 

--- a/app/src/main/java/com/example/penmasnews/model/ApprovalStorage.kt
+++ b/app/src/main/java/com/example/penmasnews/model/ApprovalStorage.kt
@@ -18,6 +18,7 @@ object ApprovalStorage {
                 EditorialEvent(
                     obj.optString("date"),
                     obj.optString("topic"),
+                    obj.optString("title"),
                     obj.optString("assignee"),
                     obj.optString("status"),
                     obj.optString("content"),
@@ -42,6 +43,7 @@ object ApprovalStorage {
             val obj = JSONObject()
             obj.put("date", item.date)
             obj.put("topic", item.topic)
+            obj.put("title", item.title)
             obj.put("assignee", item.assignee)
             obj.put("status", item.status)
             obj.put("content", item.content)

--- a/app/src/main/java/com/example/penmasnews/model/EditorialEvent.kt
+++ b/app/src/main/java/com/example/penmasnews/model/EditorialEvent.kt
@@ -8,6 +8,7 @@ import java.io.Serializable
 data class EditorialEvent(
     val date: String,
     val topic: String,
+    val title: String,
     val assignee: String,
     var status: String,
     val content: String = "",

--- a/app/src/main/java/com/example/penmasnews/network/EventService.kt
+++ b/app/src/main/java/com/example/penmasnews/network/EventService.kt
@@ -46,6 +46,7 @@ object EventService {
                         EditorialEvent(
                             obj.optString("event_date"),
                             obj.optString("topic"),
+                            obj.optString("news_title"),
                             obj.optString("assignee"),
                             obj.optString("status"),
                             obj.optString("content"),
@@ -75,6 +76,7 @@ object EventService {
         val obj = JSONObject()
         obj.put("event_date", event.date)
         obj.put("topic", event.topic)
+        obj.put("news_title", event.title)
         obj.put("assignee", event.assignee)
         obj.put("status", event.status)
         obj.put("content", event.content)
@@ -108,6 +110,7 @@ object EventService {
                 EditorialEvent(
                     json.optString("event_date"),
                     json.optString("topic"),
+                    json.optString("news_title"),
                     json.optString("assignee"),
                     json.optString("status"),
                     json.optString("content"),
@@ -134,6 +137,7 @@ object EventService {
         val obj = JSONObject()
         obj.put("event_date", event.date)
         obj.put("topic", event.topic)
+        obj.put("news_title", event.title)
         obj.put("assignee", event.assignee)
         obj.put("status", event.status)
         obj.put("content", event.content)

--- a/app/src/main/java/com/example/penmasnews/ui/AIHelperActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/AIHelperActivity.kt
@@ -8,6 +8,7 @@ import android.widget.ImageButton
 import android.content.ClipboardManager
 import android.content.Context
 import android.widget.ImageView
+import android.widget.TextView
 import android.content.Intent
 import java.io.File
 import android.text.Editable
@@ -53,6 +54,7 @@ class AIHelperActivity : AppCompatActivity() {
         val ancamanEdit = findViewById<EditText>(R.id.editAncaman)
         val typeSpinner = findViewById<android.widget.Spinner>(R.id.spinnerType)
         imageView = findViewById(R.id.imageAttachment)
+        val topicText = findViewById<TextView>(R.id.textTopic)
 
         val pasteDasar = findViewById<ImageButton>(R.id.buttonPasteDasar)
         val clearDasar = findViewById<ImageButton>(R.id.buttonClearDasar)
@@ -75,8 +77,10 @@ class AIHelperActivity : AppCompatActivity() {
 
         val index = intent.getIntExtra("index", -1)
         val extrasDate = intent.getStringExtra("date")
+        val extrasTopic = intent.getStringExtra("topic")
         val extrasTitle = intent.getStringExtra("title")
         extrasDate?.let { dateEdit.setText(it) }
+        extrasTopic?.let { topicText.text = "Topik: $it" }
         extrasTitle?.let { inputEdit.setText(it) }
 
         imageView.setOnClickListener {
@@ -412,6 +416,7 @@ class AIHelperActivity : AppCompatActivity() {
             val creator = authPrefs.getString("username", "") ?: ""
             var event = EditorialEvent(
                 dateEdit.text.toString(),
+                extrasTopic ?: "",
                 titleOutput.text.toString(),
                 "editor",
                 "dalam penulisan",

--- a/app/src/main/java/com/example/penmasnews/ui/ApprovalDetailActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/ApprovalDetailActivity.kt
@@ -27,7 +27,7 @@ class ApprovalDetailActivity : AppCompatActivity() {
         val buttonReject = findViewById<Button>(R.id.buttonReject)
 
         textDate.text = event?.date
-        textTitle.text = event?.topic
+        textTitle.text = event?.title
         textAssignee.text = event?.assignee
         textContent.text = event?.content
 

--- a/app/src/main/java/com/example/penmasnews/ui/ApprovalListAdapter.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/ApprovalListAdapter.kt
@@ -35,7 +35,7 @@ class ApprovalListAdapter(
         val item = items[position]
         val event = item.event
         holder.dateText.text = DateUtils.formatDayDate(event.date)
-        holder.titleText.text = event.topic
+        holder.titleText.text = event.title
         holder.notesText.text = event.assignee
         holder.statusText.text = item.request.status
         holder.createdByText.text = event.username

--- a/app/src/main/java/com/example/penmasnews/ui/CollaborativeEditorActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/CollaborativeEditorActivity.kt
@@ -29,6 +29,7 @@ class CollaborativeEditorActivity : AppCompatActivity() {
         setContentView(R.layout.activity_collaborative_editor)
 
         val titleEdit = findViewById<EditText>(R.id.editTitle)
+        val topicText = findViewById<TextView>(R.id.textTopic)
         val narrativeEdit = findViewById<EditText>(R.id.editNarrative)
         val assigneeEdit = findViewById<EditText>(R.id.editAssignee)
         val tagEdit = findViewById<EditText>(R.id.editTag)
@@ -90,7 +91,8 @@ class CollaborativeEditorActivity : AppCompatActivity() {
             startActivityForResult(intent, REQUEST_IMAGE)
         }
 
-        titleEdit.setText(currentEvent?.topic ?: "")
+        topicText.text = "Topik: ${currentEvent?.topic ?: ""}"
+        titleEdit.setText(currentEvent?.title ?: "")
         narrativeEdit.setText(currentEvent?.content ?: "")
         assigneeEdit.setText(currentEvent?.assignee ?: "")
         tagEdit.setText(currentEvent?.tag ?: "")
@@ -109,6 +111,7 @@ class CollaborativeEditorActivity : AppCompatActivity() {
             if (eventId != 0) {
                 val updated = EditorialEvent(
                     currentEvent?.date ?: "",
+                    currentEvent?.topic ?: "",
                     titleEdit.text.toString(),
                     assignee,
                     "dalam penulisan",

--- a/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
@@ -42,6 +42,7 @@ class EditorialCalendarActivity : AppCompatActivity() {
 
         val dateEdit = findViewById<EditText>(R.id.editDate)
         val topicSpinner = findViewById<android.widget.Spinner>(R.id.spinnerTopic)
+        val titleEdit = findViewById<EditText>(R.id.editNewsTitle)
         val notesEdit = findViewById<EditText>(R.id.editNotes)
         val assigneeEdit = findViewById<EditText>(R.id.editAssignee)
         val addButton = findViewById<Button>(R.id.buttonAddEvent)
@@ -66,7 +67,8 @@ class EditorialCalendarActivity : AppCompatActivity() {
                 val intent = android.content.Intent(this, AIHelperActivity::class.java)
                 intent.putExtra("index", index)
                 intent.putExtra("date", event.date)
-                intent.putExtra("title", event.topic)
+                intent.putExtra("topic", event.topic)
+                intent.putExtra("title", event.title)
                 intent.putExtra("assignee", event.assignee)
                 startActivity(intent)
             },
@@ -134,6 +136,7 @@ class EditorialCalendarActivity : AppCompatActivity() {
             val event = EditorialEvent(
                 dateEdit.text.toString(),
                 topicSpinner.selectedItem.toString(),
+                titleEdit.text.toString(),
                 assignee,
                 status,
                 notesEdit.text.toString(),
@@ -176,6 +179,7 @@ class EditorialCalendarActivity : AppCompatActivity() {
                         }.start()
                     }
                     dateEdit.text.clear()
+                    titleEdit.text.clear()
                     notesEdit.text.clear()
                     topicSpinner.setSelection(0)
                     assigneeEdit.text.clear()

--- a/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarAdapter.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarAdapter.kt
@@ -24,6 +24,7 @@ class EditorialCalendarAdapter(
     class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
         val dateText: TextView = view.findViewById(R.id.textDate)
         val titleText: TextView = view.findViewById(R.id.textTitle)
+        val newsTitleText: TextView = view.findViewById(R.id.textNewsTitle)
         val notesText: TextView = view.findViewById(R.id.textNotes)
         val statusText: TextView = view.findViewById(R.id.textStatus)
         val createdByText: TextView = view.findViewById(R.id.textUser)
@@ -43,6 +44,7 @@ class EditorialCalendarAdapter(
         val item = items[position]
         holder.dateText.text = "Penjadwalan : ${DateUtils.formatDayDate(item.date)}"
         holder.titleText.text = "Topik : ${item.topic}"
+        holder.newsTitleText.text = "Judul : ${item.title}"
         holder.notesText.text = "Penugasan : ${item.assignee}"
         holder.statusText.text = "Status: ${item.status}"
         holder.createdByText.text = "Created by : ${item.username}"

--- a/app/src/main/res/layout/activity_ai_helper.xml
+++ b/app/src/main/res/layout/activity_ai_helper.xml
@@ -44,6 +44,13 @@
                 android:clickable="true" />
         </com.google.android.material.textfield.TextInputLayout>
 
+        <TextView
+            android:id="@+id/textTopic"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:textStyle="bold" />
+
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/layoutInputText"
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_collaborative_editor.xml
+++ b/app/src/main/res/layout/activity_collaborative_editor.xml
@@ -23,6 +23,13 @@
             android:scaleType="centerCrop"
             android:src="@android:drawable/ic_menu_gallery" />
 
+        <TextView
+            android:id="@+id/textTopic"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:textStyle="bold" />
+
         <com.google.android.material.textfield.TextInputLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/activity_editorial_calendar.xml
+++ b/app/src/main/res/layout/activity_editorial_calendar.xml
@@ -54,6 +54,18 @@
         <com.google.android.material.textfield.TextInputLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:hint="@string/hint_input_text"
+            android:layout_marginTop="8dp">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/editNewsTitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
             android:hint="@string/hint_notes"
             android:layout_marginTop="8dp">
 

--- a/app/src/main/res/layout/item_editorial_event.xml
+++ b/app/src/main/res/layout/item_editorial_event.xml
@@ -29,6 +29,14 @@
         android:textColor="@color/approval_text" />
 
     <TextView
+        android:id="@+id/textNewsTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:textSize="14sp"
+        android:textColor="@color/approval_text" />
+
+    <TextView
         android:id="@+id/textNotes"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/cicero_sql/schema.sql
+++ b/cicero_sql/schema.sql
@@ -274,6 +274,7 @@ CREATE TABLE IF NOT EXISTS editorial_event (
   event_id SERIAL PRIMARY KEY,
   event_date TIMESTAMP NOT NULL,
   topic TEXT NOT NULL,
+  news_title TEXT,
   assignee VARCHAR(50),
   status VARCHAR(20) DEFAULT 'draft',
   content TEXT,


### PR DESCRIPTION
## Summary
- support `news_title` column in SQL schema and Kotlin data class
- show news title input on Editorial Calendar
- display news titles in calendar list items
- show topic text in the Collaborative Editor and AI Helper
- publish events using `title`

## Testing
- `npm run lint` *(fails: Could not read package.json)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687d06ceaefc8327acad95ffd4e29227