### PR TITLE
Fix editorial event title handling

### DIFF
--- a/app/src/main/java/com/example/penmasnews/network/EventService.kt
+++ b/app/src/main/java/com/example/penmasnews/network/EventService.kt
@@ -36,6 +36,12 @@ object EventService {
                     } else {
                         obj.optString("last_updated")
                     }
+                    val rawCreator = obj.optString("created_by")
+                    val username = if (rawCreator.isNotBlank()) {
+                        UserService.fetchUsername(token, rawCreator) ?: rawCreator
+                    } else {
+                        rawCreator
+                    }
                     val rawUpdated = obj.optString("updated_by")
                     val updatedBy = if (rawUpdated.isNotBlank()) {
                         UserService.fetchUsername(token, rawUpdated) ?: rawUpdated
@@ -46,7 +52,7 @@ object EventService {
                         EditorialEvent(
                             obj.optString("event_date"),
                             obj.optString("topic"),
-                            obj.optString("news_title"),
+                            obj.optString("judul_berita"),
                             obj.optString("assignee"),
                             obj.optString("status"),
                             obj.optString("content"),
@@ -57,7 +63,7 @@ object EventService {
                             obj.optInt("event_id"),
                             obj.optString("created_at"),
                             lastUpdate,
-                            obj.optString("username"),
+                            username,
                             updatedBy
                         )
                     )
@@ -76,7 +82,7 @@ object EventService {
         val obj = JSONObject()
         obj.put("event_date", event.date)
         obj.put("topic", event.topic)
-        obj.put("news_title", event.title)
+        obj.put("judul_berita", event.title)
         obj.put("assignee", event.assignee)
         obj.put("status", event.status)
         obj.put("content", event.content)
@@ -86,6 +92,8 @@ object EventService {
         obj.put("kategori", event.category)
         obj.put("created_at", event.createdAt)
         obj.put("last_update", event.lastUpdate)
+        obj.put("created_by", event.username)
+        obj.put("updated_by", event.updatedBy)
         val request = Request.Builder()
             .url(url)
             .post(obj.toString().toRequestBody(jsonType))
@@ -110,7 +118,7 @@ object EventService {
                 EditorialEvent(
                     json.optString("event_date"),
                     json.optString("topic"),
-                    json.optString("news_title"),
+                    json.optString("judul_berita"),
                     json.optString("assignee"),
                     json.optString("status"),
                     json.optString("content"),
@@ -121,7 +129,8 @@ object EventService {
                     json.optInt("event_id"),
                     json.optString("created_at"),
                     lastUpdate,
-                    json.optString("username"),
+                    UserService.fetchUsername(token, json.optString("created_by"))
+                        ?: json.optString("created_by"),
                     updatedBy
                 )
             }
@@ -137,7 +146,7 @@ object EventService {
         val obj = JSONObject()
         obj.put("event_date", event.date)
         obj.put("topic", event.topic)
-        obj.put("news_title", event.title)
+        obj.put("judul_berita", event.title)
         obj.put("assignee", event.assignee)
         obj.put("status", event.status)
         obj.put("content", event.content)

--- a/app/src/main/java/com/example/penmasnews/ui/AIHelperActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/AIHelperActivity.kt
@@ -52,7 +52,6 @@ class AIHelperActivity : AppCompatActivity() {
         val barangBuktiEdit = findViewById<EditText>(R.id.editBarangBukti)
         val pasalEdit = findViewById<EditText>(R.id.editPasal)
         val ancamanEdit = findViewById<EditText>(R.id.editAncaman)
-        val typeSpinner = findViewById<android.widget.Spinner>(R.id.spinnerType)
         imageView = findViewById(R.id.imageAttachment)
         val topicText = findViewById<TextView>(R.id.textTopic)
 
@@ -144,7 +143,6 @@ class AIHelperActivity : AppCompatActivity() {
 
         val allViews = listOf(
             layoutInput,
-            typeSpinner,
             layoutDasar,
             layoutTersangka,
             layoutTKP,
@@ -156,19 +154,7 @@ class AIHelperActivity : AppCompatActivity() {
             layoutNotes,
         )
 
-        val pressFields = listOf(
-            layoutInput,
-            typeSpinner,
-            layoutDasar,
-            layoutTersangka,
-            layoutTKP,
-            layoutKronologi,
-            layoutModus,
-            layoutBarangBukti,
-            layoutPasal,
-            layoutAncaman,
-            layoutNotes,
-        )
+        val pressFields = allViews
 
         val pressText = listOf(
             inputEdit,
@@ -185,7 +171,6 @@ class AIHelperActivity : AppCompatActivity() {
 
         val pressFocus = listOf<android.view.View>(
             inputEdit,
-            typeSpinner,
             dasarEdit,
             tersangkaEdit,
             tkpEdit,
@@ -194,23 +179,6 @@ class AIHelperActivity : AppCompatActivity() {
             barangBuktiEdit,
             pasalEdit,
             ancamanEdit,
-            notesEdit,
-        )
-
-        val onlineFields = listOf(
-            layoutInput,
-            typeSpinner,
-            layoutNotes,
-        )
-
-        val onlineText = listOf(
-            inputEdit,
-            notesEdit,
-        )
-
-        val onlineFocus = listOf<android.view.View>(
-            inputEdit,
-            typeSpinner,
             notesEdit,
         )
 
@@ -225,29 +193,11 @@ class AIHelperActivity : AppCompatActivity() {
             generateButton.visibility = if (ready) android.view.View.VISIBLE else android.view.View.GONE
         }
 
-        fun updateForType(press: Boolean) {
-            isPressRelease = press
-            fields = if (press) pressFields else onlineFields
-            textFields = if (press) pressText else onlineText
-            focusFields = if (press) pressFocus else onlineFocus
-            allViews.forEach { view ->
-                if (view !in listOf(layoutInput, typeSpinner)) {
-                    view.visibility = android.view.View.GONE
-                }
-            }
-            currentIndex = listOf(layoutInput, typeSpinner).count { it.isShown }
-            addColumnButton.visibility = if (currentIndex < fields.size) android.view.View.VISIBLE else android.view.View.GONE
-            checkReady()
+        allViews.forEach { view ->
+            view.visibility = android.view.View.GONE
         }
-
-        typeSpinner.onItemSelectedListener = object : android.widget.AdapterView.OnItemSelectedListener {
-            override fun onItemSelected(parent: android.widget.AdapterView<*>, view: android.view.View?, position: Int, id: Long) {
-                updateForType(position == 0)
-            }
-            override fun onNothingSelected(parent: android.widget.AdapterView<*>) {}
-        }
-
-        updateForType(true)
+        currentIndex = 0
+        addColumnButton.visibility = android.view.View.VISIBLE
         textFields.forEach { field ->
             field.addTextChangedListener(object : TextWatcher {
                 override fun afterTextChanged(s: Editable?) { checkReady() }
@@ -413,7 +363,7 @@ class AIHelperActivity : AppCompatActivity() {
         saveButton.setOnClickListener {
             val events = EventStorage.loadEvents(this)
             val authPrefs = getSharedPreferences("auth", MODE_PRIVATE)
-            val creator = authPrefs.getString("username", "") ?: ""
+            val creator = authPrefs.getString("userId", "") ?: ""
             var event = EditorialEvent(
                 dateEdit.text.toString(),
                 extrasTopic ?: "",

--- a/app/src/main/java/com/example/penmasnews/ui/ApprovalDetailActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/ApprovalDetailActivity.kt
@@ -44,7 +44,7 @@ class ApprovalDetailActivity : AppCompatActivity() {
         if (event == null || request == null) return
         val prefs = getSharedPreferences("auth", MODE_PRIVATE)
         val token = prefs.getString("token", null)
-        val user = prefs.getString("username", "unknown") ?: "unknown"
+        val user = prefs.getString("userId", "unknown") ?: "unknown"
         if (token != null) {
             Thread {
                 val updatedEvent = event.copy(

--- a/app/src/main/java/com/example/penmasnews/ui/CollaborativeEditorActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/CollaborativeEditorActivity.kt
@@ -124,7 +124,7 @@ class CollaborativeEditorActivity : AppCompatActivity() {
                     currentEvent?.createdAt ?: "",
                     DateUtils.now(),
                     currentEvent?.username ?: "",
-                    authPrefs.getString("username", currentEvent?.updatedBy ?: "") ?: currentEvent?.updatedBy ?: ""
+                    authPrefs.getString("userId", currentEvent?.updatedBy ?: "") ?: currentEvent?.updatedBy ?: ""
                 )
                 Thread {
                     val success = EventStorage.updateEvent(this, updated)
@@ -185,7 +185,7 @@ class CollaborativeEditorActivity : AppCompatActivity() {
                 val updated = baseEvent.copy(
                     status = newStatus,
                     lastUpdate = DateUtils.now(),
-                    updatedBy = authPrefs.getString("username", baseEvent.updatedBy) ?: baseEvent.updatedBy
+                    updatedBy = authPrefs.getString("userId", baseEvent.updatedBy) ?: baseEvent.updatedBy
                 )
                 Thread {
                     EventStorage.updateEvent(this, updated)

--- a/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
+++ b/app/src/main/java/com/example/penmasnews/ui/EditorialCalendarActivity.kt
@@ -132,7 +132,7 @@ class EditorialCalendarActivity : AppCompatActivity() {
             val status = "ide"
 
             val authPrefs = getSharedPreferences("auth", MODE_PRIVATE)
-            val creator = authPrefs.getString("username", "") ?: ""
+            val creator = authPrefs.getString("userId", "") ?: ""
             val event = EditorialEvent(
                 dateEdit.text.toString(),
                 topicSpinner.selectedItem.toString(),
@@ -225,7 +225,7 @@ class EditorialCalendarActivity : AppCompatActivity() {
             val result = cms.publishToBlogspot(event, token)
             val prefsAuth = getSharedPreferences("auth", MODE_PRIVATE)
             val authToken = prefsAuth.getString("token", null)
-            val user = prefsAuth.getString("username", "") ?: ""
+            val user = prefsAuth.getString("userId", "") ?: ""
             if (result.success && authToken != null) {
                 val updated = event.copy(
                     status = "published",
@@ -256,7 +256,7 @@ class EditorialCalendarActivity : AppCompatActivity() {
             val result = cms.publishToWordpress(event)
             val prefsAuth = getSharedPreferences("auth", MODE_PRIVATE)
             val authToken = prefsAuth.getString("token", null)
-            val user = prefsAuth.getString("username", "") ?: ""
+            val user = prefsAuth.getString("userId", "") ?: ""
             if (result.success && authToken != null) {
                 val updated = event.copy(
                     status = "published",

--- a/app/src/main/res/layout/activity_ai_helper.xml
+++ b/app/src/main/res/layout/activity_ai_helper.xml
@@ -65,14 +65,6 @@
                 android:layout_height="wrap_content" />
         </com.google.android.material.textfield.TextInputLayout>
 
-        <Spinner
-            android:id="@+id/spinnerType"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:entries="@array/news_type_array"
-            android:prompt="@string/label_news_type"
-            android:layout_marginTop="8dp"
-            android:visibility="gone" />
 
         <LinearLayout
             android:id="@+id/layoutDasar"

--- a/cicero_sql/schema.sql
+++ b/cicero_sql/schema.sql
@@ -274,7 +274,7 @@ CREATE TABLE IF NOT EXISTS editorial_event (
   event_id SERIAL PRIMARY KEY,
   event_date TIMESTAMP NOT NULL,
   topic TEXT NOT NULL,
-  news_title TEXT,
+  judul_berita TEXT,
   assignee VARCHAR(50),
   status VARCHAR(20) DEFAULT 'draft',
   content TEXT,

--- a/docs/postgresql_schema.sql
+++ b/docs/postgresql_schema.sql
@@ -4,6 +4,7 @@ CREATE TABLE IF NOT EXISTS editorial_event (
   event_id SERIAL PRIMARY KEY,
   event_date TIMESTAMP NOT NULL,
   topic TEXT NOT NULL,
+  judul_berita TEXT,
   assignee VARCHAR(50),
   status VARCHAR(20) DEFAULT 'draft',
   content TEXT,


### PR DESCRIPTION
## Summary
- rename `news_title` column to `judul_berita`
- send created/updated user ids when saving editorial events
- resolve user ids to usernames when loading events
- drop type selection spinner from AI helper

## Testing
- `npm run lint` *(fails: ENOENT package.json)*
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687d104001408327bd3ab83d29a0ef86